### PR TITLE
chore: Upgrade next seo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "gatsby-plugin-gatsby-cloud": "^3.1.0",
     "gatsby-plugin-image": "^1.11.0",
     "gatsby-plugin-manifest": "^3.11.0",
-    "gatsby-plugin-next-seo": "^1.7.0",
+    "gatsby-plugin-next-seo": "^1.8.0",
     "gatsby-plugin-nprogress": "^3.11.0",
     "gatsby-plugin-offline": "^4.11.0",
     "gatsby-plugin-robots-txt": "^1.5.1",
     "gatsby-plugin-root-import": "^2.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-helmet-async": "^1.0.9",
+    "react-helmet-async": "^1.1.2",
     "swr": "^0.5.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6529,10 +6529,10 @@ gatsby-plugin-manifest@^3.11.0:
     semver "^7.3.5"
     sharp "^0.28.3"
 
-gatsby-plugin-next-seo@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-next-seo/-/gatsby-plugin-next-seo-1.7.0.tgz#fc25a4b077611201b1b21c846a5b28342214480c"
-  integrity sha512-H3XtyubS/QwBP7shpsxkpeV8HysROm/J5ImKgcD7bDmvkUXAYFyqb8hUzMGfnUVUUUY3cWvK1zacUhKTPkafbw==
+gatsby-plugin-next-seo@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-next-seo/-/gatsby-plugin-next-seo-1.8.0.tgz#f19464e2382542630c622b37c6b1efe1feda26d0"
+  integrity sha512-wu9lfYciWnlQVu2On7wWMYTTzCto4nDYLCW7Glu6XzOwyYnBCdYAumVG4C7ZRnwBYFs1spmvqAoGBPuosICCYw==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/react-helmet" "^6.0.0"
@@ -11244,10 +11244,10 @@ react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet-async@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.9.tgz#5b9ed2059de6b4aab47f769532f9fbcbce16c5ca"
-  integrity sha512-N+iUlo9WR3/u9qGMmP4jiYfaD6pe9IvDTapZLFJz2D3xlTlCM1Bzy4Ab3g72Nbajo/0ZyW+W9hdz8Hbe4l97pQ==
+react-helmet-async@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.1.2.tgz#653b7e6bbfdd239c5dcd6b8df2811c7a363b8334"
+  integrity sha512-LTTzDDkyIleT/JJ6T/uqx7Y8qi1EuPPSiJawQY/nHHz0h7SPDT6HxP1YDDQx/fzcVxCqpWEEMS3QdrSrNkJYhg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     invariant "^2.2.4"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes that annoying issue with:
```
Plugin gatsby-plugin-next-seo is not compatible with your gatsby version 3.13.0 - It requires gatsby@^2
```

