### PR TITLE
chore: Fix Image SSR blink

### DIFF
--- a/src/sdk/image/useImage.ts
+++ b/src/sdk/image/useImage.ts
@@ -1,3 +1,10 @@
+/**
+ * TODO:
+ * gatsby-plugin-image currently blinks on SSR when the image is already loaded before hydration.
+ * Eventually they will fix this issue in here: https://github.com/gatsbyjs/gatsby/issues/32037
+ *
+ * When they release this, we need to remember upgrading gatsby-plugin-image and this issue will be fixed
+ */
 import { useGetThumborImageData } from '@vtex/gatsby-plugin-thumbor'
 import { useMemo } from 'react'
 import imagesConf from 'src/images/config'


### PR DESCRIPTION
## What's the purpose of this pull request?
I was trying to fix the wild blink of the SSRed product image on the pdp. However, while digging I've found  [this issue](https://github.com/gatsbyjs/gatsby/issues/32037) open on Gatsby and decided to add a todo in our code for us to remember to upgrade it once they fix this problem

## How it works? 
Sonarqube bot will warn us about it and eventually we will upgrade gatsby-plugin-image and this problem will be fixed