### PR TITLE
feat: Add view-item event

### DIFF
--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -9,14 +9,11 @@ import { pages, options } from '../global'
 describe('add_to_cart event', () => {
   beforeEach(() => {
     cy.clearIDB()
-    cy.clearDataLayer()
   })
 
   const testAddToCartEvent = (skuId) => {
     cy.window().then((window) => {
       const { dataLayer } = window
-
-      expect(dataLayer).to.have.length(1)
 
       const event = dataLayer.find((e) => e.type === 'add_to_cart')
 
@@ -63,6 +60,42 @@ describe('add_to_cart event', () => {
         const skuId = $btn.attr('data-sku')
 
         testAddToCartEvent(skuId)
+      })
+  })
+})
+
+describe('view_item event', () => {
+  const dataLayerHasEvent = (eventName) => {
+    return cy.window().then((window) => {
+      const allEvents = window.dataLayer.map((evt) => evt.type)
+
+      expect(allEvents).to.include(eventName)
+    })
+  }
+
+  const eventDataHasCurrencyProperty = () => {
+    return cy.window().then((window) => {
+      const allEvents = window.dataLayer.map((evt) => evt.data || {})
+
+      allEvents.forEach((event) => {
+        if (event.value !== undefined) {
+          expect(event).to.have.property('value')
+          expect(event).to.have.property('currency')
+        }
+      })
+    })
+  }
+
+  it('add view_item event in data layer', () => {
+    cy.visit(pages.collection, options)
+    cy.waitForHydration()
+
+    cy.getById('product-link')
+      .first()
+      .click()
+      .then(() => {
+        dataLayerHasEvent('view_item')
+        eventDataHasCurrencyProperty()
       })
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,12 +36,6 @@ Cypress.Commands.add('clearIDB', () => {
   return indexedDB.deleteDatabase('keyval-store')
 })
 
-Cypress.Commands.add('clearDataLayer', () => {
-  return cy.window().then((window) => {
-    window.dataLayer = []
-  })
-})
-
 Cypress.Commands.add('itemsInCart', (count) => {
   return cy.getById('cart-toggle').should(($toggle) => {
     expect($toggle.attr('data-items')).to.eq(count.toString())

--- a/src/components/product/ProductSummary/ProductSummary.tsx
+++ b/src/components/product/ProductSummary/ProductSummary.tsx
@@ -8,12 +8,30 @@ import { useImage } from 'src/sdk/image/useImage'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProductLink } from 'src/sdk/product/useProductLink'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
+import type { ViewItemData } from '@vtex/store-sdk'
 
 interface Props {
   product: ProductSummary_ProductFragment
 }
 
 function ProductSummary({ product }: Props) {
+  const productOptions: ViewItemData = {
+    value: product?.offers?.offers[0]?.price,
+    items: [
+      {
+        item_id: product?.id,
+        item_name: product?.name,
+        index: 0,
+        price: product?.offers?.offers[0]?.price,
+        discount:
+          product?.offers?.offers[0]?.listPrice -
+          product?.offers?.offers[0]?.price,
+        item_brand: product?.brand?.name,
+        item_variant: product?.isVariantOf?.name,
+      },
+    ],
+  }
+
   const {
     id,
     slug,
@@ -31,7 +49,7 @@ function ProductSummary({ product }: Props) {
     [spotPrice, offers]
   )
 
-  const linkProps = useProductLink({ slug })
+  const linkProps = useProductLink({ slug, product: productOptions })
   const image = useImage(img.url, 'product.summary')
   const buyProps = useBuyButton({
     id,
@@ -82,6 +100,9 @@ export const fragment = graphql`
     id: productID
     slug
     sku
+    brand {
+      brandName: name
+    }
     name
     gtin
 
@@ -104,6 +125,7 @@ export const fragment = graphql`
       offers {
         price
         listPrice
+        quantity
         seller {
           identifier
         }

--- a/src/components/product/ProductSummary/ProductSummary.tsx
+++ b/src/components/product/ProductSummary/ProductSummary.tsx
@@ -6,7 +6,6 @@ import DiscountBadge from 'src/components/ui/DiscountBadge'
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useImage } from 'src/sdk/image/useImage'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
-import type { ProductLinkOptions } from 'src/sdk/product/useProductLink'
 import { useProductLink } from 'src/sdk/product/useProductLink'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
 
@@ -17,7 +16,6 @@ interface Props {
 function ProductSummary({ product }: Props) {
   const {
     id,
-    slug,
     sku,
     gtin: referenceId,
     name: variantName,
@@ -27,29 +25,12 @@ function ProductSummary({ product }: Props) {
     offers: { lowPrice: spotPrice, offers },
   } = product
 
-  const productOptions: ProductLinkOptions = {
-    slug,
-    value: product.offers.offers[0]?.price,
-    items: [
-      {
-        item_id: product.id,
-        item_name: product.name,
-        index: 0,
-        price: product.offers.offers[0]?.price,
-        discount:
-          product.offers.offers[0]?.listPrice - product.offers.offers[0]?.price,
-        item_brand: product.brand.name,
-        item_variant: product.isVariantOf.name,
-      },
-    ],
-  }
-
   const { listPrice, seller } = useMemo(
     () => offers.find((x) => x.price === spotPrice)!,
     [spotPrice, offers]
   )
 
-  const linkProps = useProductLink(productOptions)
+  const linkProps = useProductLink(product)
   const image = useImage(img.url, 'product.summary')
   const buyProps = useBuyButton({
     id,

--- a/src/components/product/ProductSummary/ProductSummary.tsx
+++ b/src/components/product/ProductSummary/ProductSummary.tsx
@@ -6,32 +6,15 @@ import DiscountBadge from 'src/components/ui/DiscountBadge'
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useImage } from 'src/sdk/image/useImage'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
+import type { ProductLinkOptions } from 'src/sdk/product/useProductLink'
 import { useProductLink } from 'src/sdk/product/useProductLink'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
-import type { ViewItemData } from '@vtex/store-sdk'
 
 interface Props {
   product: ProductSummary_ProductFragment
 }
 
 function ProductSummary({ product }: Props) {
-  const productOptions: ViewItemData = {
-    value: product?.offers?.offers[0]?.price,
-    items: [
-      {
-        item_id: product?.id,
-        item_name: product?.name,
-        index: 0,
-        price: product?.offers?.offers[0]?.price,
-        discount:
-          product?.offers?.offers[0]?.listPrice -
-          product?.offers?.offers[0]?.price,
-        item_brand: product?.brand?.name,
-        item_variant: product?.isVariantOf?.name,
-      },
-    ],
-  }
-
   const {
     id,
     slug,
@@ -44,12 +27,29 @@ function ProductSummary({ product }: Props) {
     offers: { lowPrice: spotPrice, offers },
   } = product
 
+  const productOptions: ProductLinkOptions = {
+    slug,
+    value: product.offers.offers[0]?.price,
+    items: [
+      {
+        item_id: product.id,
+        item_name: product.name,
+        index: 0,
+        price: product.offers.offers[0]?.price,
+        discount:
+          product.offers.offers[0]?.listPrice - product.offers.offers[0]?.price,
+        item_brand: product.brand.name,
+        item_variant: product.isVariantOf.name,
+      },
+    ],
+  }
+
   const { listPrice, seller } = useMemo(
     () => offers.find((x) => x.price === spotPrice)!,
     [spotPrice, offers]
   )
 
-  const linkProps = useProductLink({ slug, product: productOptions })
+  const linkProps = useProductLink(productOptions)
   const image = useImage(img.url, 'product.summary')
   const buyProps = useBuyButton({
     id,

--- a/src/sdk/analytics/index.tsx
+++ b/src/sdk/analytics/index.tsx
@@ -1,19 +1,13 @@
 import { useAnalyticsEvent } from '@vtex/store-sdk'
 import type { PropsWithChildren } from 'react'
 
-declare global {
-  interface Window {
-    dataLayer?: any[]
-  }
-}
-
 if (typeof window !== 'undefined') {
   window.dataLayer = window.dataLayer ?? []
 }
 
 export const AnalyticsHandler = ({ children }: PropsWithChildren<unknown>) => {
   useAnalyticsEvent((event) => {
-    window?.dataLayer?.push(event)
+    window.dataLayer.push(event)
   })
 
   return children

--- a/src/sdk/analytics/index.tsx
+++ b/src/sdk/analytics/index.tsx
@@ -1,13 +1,19 @@
 import { useAnalyticsEvent } from '@vtex/store-sdk'
 import type { PropsWithChildren } from 'react'
 
+declare global {
+  interface Window {
+    dataLayer?: any[]
+  }
+}
+
 if (typeof window !== 'undefined') {
-  window.dataLayer = window.dataLayer || []
+  window.dataLayer = window.dataLayer ?? []
 }
 
 export const AnalyticsHandler = ({ children }: PropsWithChildren<unknown>) => {
   useAnalyticsEvent((event) => {
-    window.dataLayer.push(event)
+    window?.dataLayer?.push(event)
   })
 
   return children

--- a/src/sdk/product/useProductLink.ts
+++ b/src/sdk/product/useProductLink.ts
@@ -1,15 +1,11 @@
-import type {
-  CurrencyCode,
-  Item,
-  ViewItemData,
-  ViewItemEvent,
-} from '@vtex/store-sdk'
+import type { ProductSummary_ProductFragment } from '@generated/graphql'
+import type { CurrencyCode, ViewItemData, ViewItemEvent } from '@vtex/store-sdk'
 import { useSession, sendAnalyticsEvent } from '@vtex/store-sdk'
 import { useMemo } from 'react'
 
 export type ProductLinkOptions = {
   slug: string
-} & ViewItemData
+} & ProductSummary_ProductFragment
 
 export const useProductLink = ({ slug, ...product }: ProductLinkOptions) => {
   const {
@@ -17,15 +13,29 @@ export const useProductLink = ({ slug, ...product }: ProductLinkOptions) => {
   } = useSession()
 
   return useMemo(() => {
+    const viewItemEventData: ViewItemData = {
+      value: product.offers.offers[0]?.price,
+      items: [
+        {
+          item_id: product.id,
+          item_name: product.name,
+          index: 0,
+          price: product.offers.offers[0]?.price,
+          discount:
+            product.offers.offers[0]?.listPrice -
+            product.offers.offers[0]?.price,
+          item_brand: product.brand.name,
+          item_variant: product.isVariantOf.name,
+        },
+      ],
+    }
+
     const onClick = () => {
       const currency = code as CurrencyCode
-      const productItems = product.items?.map((p) => {
-        return { ...p, currency } as Item
-      })
 
       sendAnalyticsEvent<ViewItemEvent>({
         type: 'view_item',
-        data: { ...product, currency, items: productItems },
+        data: { ...viewItemEventData, currency },
       })
     }
 
@@ -34,5 +44,5 @@ export const useProductLink = ({ slug, ...product }: ProductLinkOptions) => {
       onClick,
       'data-testid': 'product-link',
     }
-  }, [product, slug, code])
+  }, [slug, code, product])
 }

--- a/src/sdk/product/useProductLink.ts
+++ b/src/sdk/product/useProductLink.ts
@@ -9,25 +9,23 @@ import { useMemo } from 'react'
 
 export type ProductLinkOptions = {
   slug: string
-  product: ViewItemData
-}
+} & ViewItemData
 
-export const useProductLink = ({ product, slug }: ProductLinkOptions) => {
+export const useProductLink = ({ slug, ...product }: ProductLinkOptions) => {
   const {
     currency: { code },
   } = useSession()
 
   return useMemo(() => {
     const onClick = () => {
-      product.currency = code as CurrencyCode
-
-      product.items = product.items?.map((p) => {
-        return { ...p, currency: code } as Item
+      const currency = code as CurrencyCode
+      const productItems = product.items?.map((p) => {
+        return { ...p, currency } as Item
       })
 
       sendAnalyticsEvent<ViewItemEvent>({
         type: 'view_item',
-        data: product,
+        data: { ...product, currency, items: productItems },
       })
     }
 

--- a/src/sdk/product/useProductLink.ts
+++ b/src/sdk/product/useProductLink.ts
@@ -1,13 +1,34 @@
+import type {
+  CurrencyCode,
+  Item,
+  ViewItemData,
+  ViewItemEvent,
+} from '@vtex/store-sdk'
+import { useSession, sendAnalyticsEvent } from '@vtex/store-sdk'
 import { useMemo } from 'react'
 
-interface Options {
+export type ProductLinkOptions = {
   slug: string
+  product: ViewItemData
 }
 
-export const useProductLink = ({ slug }: Options) =>
-  useMemo(() => {
+export const useProductLink = ({ product, slug }: ProductLinkOptions) => {
+  const {
+    currency: { code },
+  } = useSession()
+
+  return useMemo(() => {
     const onClick = () => {
-      // TODO: Add onClick analytics event
+      product.currency = code as CurrencyCode
+
+      product.items = product.items?.map((p) => {
+        return { ...p, currency: code } as Item
+      })
+
+      sendAnalyticsEvent<ViewItemEvent>({
+        type: 'view_item',
+        data: product,
+      })
     }
 
     return {
@@ -15,4 +36,5 @@ export const useProductLink = ({ slug }: Options) =>
       onClick,
       'data-testid': 'product-link',
     }
-  }, [slug])
+  }, [product, slug, code])
+}


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?
This PR add trigger for view-item analytics event, according to GA4.

## How it works? 
For this, when an item is clicked the PR add in `window.dataLayer` one more event, with name and properties according to GA4.

## How to test it?
This PR also add cypress tests for this event, testing if the event is added to dataLayer and if the properties has been added too.

## References
[GA4](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#view_item) 
