### PR TITLE
chore: Drop thumborize.me

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -110,7 +110,7 @@ module.exports = {
         server:
           isCI && !isNetlify
             ? 'http://thumbor.vtex.internal'
-            : 'http://thumbor.thumborize.me',
+            : 'https://thumbor-dev-server.vtex.io',
         ...((isProduction || isNetlify) && {
           basePath: '/assets',
           sizes: getSizes(images),


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR drops the free thumborize.me thumbor server in favor of our self hosted server on vtex.io

This works only on dev mode and should reduce the problems we were getting on dev mode for images not loading correctly. This happens because thumborize.me is often down because it's free and used by many people on the internet

