### PR TITLE
feat: send 'remove_from_cart' analytics event 

### DIFF
--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -112,8 +112,6 @@ describe('remove_from_cart event', () => {
 
           testRemoveFromCartEvent(skuId)
         })
-      cy.getById('cart-item').should('not.exist')
-      cy.getById('checkout-button').should('be.enabled')
     })
   })
 })

--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -36,39 +36,41 @@ describe('add_to_cart event', () => {
     })
   }
 
-  it('add add_to_cart event in the data layer at product description page', () => {
-    cy.visit(pages.pdp, options)
-    cy.waitForHydration()
+  context('when adding a product to cart', () => {
+    it('adds add_to_cart event in the data layer at product description page', () => {
+      cy.visit(pages.pdp, options)
+      cy.waitForHydration()
 
-    cy.itemsInCart(0)
+      cy.itemsInCart(0)
 
-    // Add to cart
-    cy.getById('buy-button')
-      .click()
-      .then(($btn) => {
-        cy.itemsInCart(1)
-        const skuId = $btn.attr('data-sku')
+      // Add to cart
+      cy.getById('buy-button')
+        .click()
+        .then(($btn) => {
+          cy.itemsInCart(1)
+          const skuId = $btn.attr('data-sku')
 
-        testAddToCartEvent(skuId)
-      })
-  })
+          testAddToCartEvent(skuId)
+        })
+    })
 
-  it('add add_to_cart event in the data layer at the product listing page', () => {
-    cy.visit(pages.collection, options)
-    cy.waitForHydration()
+    it('adds add_to_cart event in the data layer at the product listing page', () => {
+      cy.visit(pages.collection, options)
+      cy.waitForHydration()
 
-    cy.itemsInCart(0)
+      cy.itemsInCart(0)
 
-    // Add to cart
-    cy.getById('buy-button')
-      .first()
-      .click()
-      .then(($btn) => {
-        cy.itemsInCart(1)
-        const skuId = $btn.attr('data-sku')
+      // Add to cart
+      cy.getById('buy-button')
+        .first()
+        .click()
+        .then(($btn) => {
+          cy.itemsInCart(1)
+          const skuId = $btn.attr('data-sku')
 
-        testAddToCartEvent(skuId)
-      })
+          testAddToCartEvent(skuId)
+        })
+    })
   })
 })
 

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -4,10 +4,10 @@ import Button from 'src/components/ui/Button'
 import { useRemoveButton } from 'src/sdk/cart/useRemoveButton'
 import { useImage } from 'src/sdk/image/useImage'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
-import type { CartItem as ICartItem } from 'src/sdk/cart/validate'
+import type { AnalyticsCartItem } from 'src/sdk/analytics/types'
 
 interface Props {
-  item: ICartItem
+  item: AnalyticsCartItem
 }
 
 function CartItem({ item }: Props) {

--- a/src/sdk/analytics/types.ts
+++ b/src/sdk/analytics/types.ts
@@ -1,0 +1,34 @@
+import type {
+  AddToCartEvent,
+  AddToCartData,
+  RemoveFromCartEvent,
+  RemoveFromCartData,
+  Item as AnalyticsItem,
+} from '@faststore/sdk'
+import type { CartItem } from 'src/sdk/cart/validate'
+
+type AdditionalItemProperties = {
+  product_reference_id: string | null
+  sku_name: string | null
+}
+
+type AdditionalAnalyticsProperties = {
+  name: string
+  brand: string
+  referenceId: string
+  productId: string
+}
+
+export interface VTEXRemoveFromCartEvent extends RemoveFromCartEvent {
+  data: RemoveFromCartData & {
+    items: Array<AnalyticsItem & AdditionalItemProperties>
+  }
+}
+
+export interface VTEXAddToCartEvent extends AddToCartEvent {
+  data: AddToCartData & {
+    items: Array<AnalyticsItem & AdditionalItemProperties>
+  }
+}
+
+export type AnalyticsCartItem = CartItem & AdditionalAnalyticsProperties

--- a/src/sdk/cart/useBuyButton.ts
+++ b/src/sdk/cart/useBuyButton.ts
@@ -16,8 +16,6 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
     currency: { code },
   } = useSession()
 
-  const currency = code as CurrencyCode
-
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       e.preventDefault()
@@ -29,11 +27,11 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
       sendAnalyticsEvent<VTEXAddToCartEvent>({
         type: 'add_to_cart',
         data: {
-          currency,
+          currency: code as CurrencyCode,
           value: item.price * item.quantity, // TODO: In the future, we can explore more robust ways of calculating the value (gift items, discounts, etc.).
           items: [
             {
-              currency,
+              currency: code as CurrencyCode,
               item_id: item.productId,
               quantity: item.quantity,
               item_variant: item.itemOffered.sku,
@@ -50,7 +48,7 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
       addItem(item)
       openMinicart()
     },
-    [addItem, currency, item, openMinicart]
+    [addItem, code, item, openMinicart]
   )
 
   return {

--- a/src/sdk/cart/useBuyButton.ts
+++ b/src/sdk/cart/useBuyButton.ts
@@ -1,35 +1,13 @@
 import { useCallback } from 'react'
-import type {
-  AddToCartEvent,
-  AddToCartData,
-  Item as AnalyticsItem,
-  CurrencyCode,
-} from '@faststore/sdk'
 import { sendAnalyticsEvent, useSession } from '@faststore/sdk'
+import type { CurrencyCode } from '@faststore/sdk'
+import type {
+  AnalyticsCartItem,
+  VTEXAddToCartEvent,
+} from 'src/sdk/analytics/types'
 
 import { useUI } from '../ui'
 import { useCart } from './useCart'
-import type { CartItem } from './validate'
-
-type AdditionalItemProperties = {
-  product_reference_id: string | null
-  sku_name: string | null
-}
-
-interface VTEXAddToCartEvent extends AddToCartEvent {
-  data: AddToCartData & {
-    items: Array<AnalyticsItem & AdditionalItemProperties>
-  }
-}
-
-type AdditionalAnalyticsProperties = {
-  name: string
-  brand: string
-  referenceId: string
-  productId: string
-}
-
-type AnalyticsCartItem = CartItem & AdditionalAnalyticsProperties
 
 export const useBuyButton = (item: AnalyticsCartItem | null) => {
   const { addItem } = useCart()

--- a/src/sdk/cart/useBuyButton.ts
+++ b/src/sdk/cart/useBuyButton.ts
@@ -36,7 +36,7 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
               currency,
               item_id: item.productId,
               quantity: item.quantity,
-              item_variant: item.id,
+              item_variant: item.itemOffered.sku,
               item_name: item.name,
               item_brand: item.brand,
               price: item.price,
@@ -47,16 +47,7 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
         },
       })
 
-      const { price, listPrice, seller, quantity, itemOffered } = item
-      const cartItem: Omit<CartItem, 'id'> = {
-        price,
-        listPrice,
-        seller,
-        quantity,
-        itemOffered,
-      }
-
-      addItem(cartItem)
+      addItem(item)
       openMinicart()
     },
     [addItem, currency, item, openMinicart]

--- a/src/sdk/cart/useCart.ts
+++ b/src/sdk/cart/useCart.ts
@@ -3,15 +3,16 @@ import { useCallback, useMemo } from 'react'
 
 import { getItemId, isGift } from './validate'
 import type { Cart, CartItem } from './validate'
+import type { AnalyticsCartItem } from '../analytics/types'
 
 export const useCart = () => {
-  const { addItem: addItemToCart, ...cart } = useSDKCart<CartItem>()
+  const { addItem: addItemToCart, ...cart } = useSDKCart<AnalyticsCartItem>()
 
   const addItem = useCallback(
-    (item: Omit<CartItem, 'id'>) => {
+    <Item extends Omit<AnalyticsCartItem, 'id'>>(item: Item) => {
       const cartItem = {
-        id: getItemId(item),
         ...item,
+        id: getItemId(item),
       }
 
       addItemToCart(cartItem)

--- a/src/sdk/cart/useCart.ts
+++ b/src/sdk/cart/useCart.ts
@@ -24,7 +24,7 @@ export const useCart = () => {
     () => ({
       ...cart,
       addItem,
-      messages: (cart as Cart).messages,
+      messages: (cart as Cart<CartItem>).messages,
       gifts: cart.items.filter((item) => isGift(item)),
       items: cart.items.filter((item) => !isGift(item)),
       totalUniqueItems: cart.items.length,

--- a/src/sdk/cart/useRemoveButton.ts
+++ b/src/sdk/cart/useRemoveButton.ts
@@ -2,12 +2,22 @@
  * TODO: Add analytics events here
  * */
 import { useCallback } from 'react'
+import { sendAnalyticsEvent, useSession } from '@faststore/sdk'
+import type { CurrencyCode } from '@faststore/sdk'
+import type {
+  AnalyticsCartItem,
+  VTEXRemoveFromCartEvent,
+} from 'src/sdk/analytics/types'
 
 import { useCart } from './useCart'
-import type { CartItem } from './validate'
 
-export const useRemoveButton = (item: CartItem | null | undefined) => {
+export const useRemoveButton = (item: AnalyticsCartItem | null | undefined) => {
   const { removeItem } = useCart()
+  const {
+    currency: { code },
+  } = useSession()
+
+  const currency = code as CurrencyCode
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -17,10 +27,35 @@ export const useRemoveButton = (item: CartItem | null | undefined) => {
         return
       }
 
+      sendAnalyticsEvent<VTEXRemoveFromCartEvent>({
+        type: 'remove_from_cart',
+        data: {
+          currency,
+          value: item.price * item.quantity, // TODO: In the future, we can explore more robust ways of calculating the value (gift items, discounts, etc.).
+          items: [
+            {
+              item_id: item.productId,
+              item_name: item.name,
+              currency,
+              item_brand: item.brand,
+              item_variant: item.itemOffered.sku,
+              price: item.price,
+              quantity: item.quantity,
+              product_reference_id: item.referenceId,
+              sku_name: item.itemOffered.name,
+            },
+          ],
+        },
+      })
+
       removeItem(item.id)
     },
-    [item, removeItem]
+    [currency, item, removeItem]
   )
 
-  return { onClick, 'data-testid': 'remove-from-cart-button' }
+  return {
+    onClick,
+    'data-testid': 'remove-from-cart-button',
+    'data-sku': item?.itemOffered.sku,
+  }
 }

--- a/src/sdk/cart/useRemoveButton.ts
+++ b/src/sdk/cart/useRemoveButton.ts
@@ -17,8 +17,6 @@ export const useRemoveButton = (item: AnalyticsCartItem | null | undefined) => {
     currency: { code },
   } = useSession()
 
-  const currency = code as CurrencyCode
-
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       e.preventDefault()
@@ -30,13 +28,13 @@ export const useRemoveButton = (item: AnalyticsCartItem | null | undefined) => {
       sendAnalyticsEvent<VTEXRemoveFromCartEvent>({
         type: 'remove_from_cart',
         data: {
-          currency,
+          currency: code as CurrencyCode,
           value: item.price * item.quantity, // TODO: In the future, we can explore more robust ways of calculating the value (gift items, discounts, etc.).
           items: [
             {
               item_id: item.productId,
               item_name: item.name,
-              currency,
+              currency: code as CurrencyCode,
               item_brand: item.brand,
               item_variant: item.itemOffered.sku,
               price: item.price,
@@ -50,7 +48,7 @@ export const useRemoveButton = (item: AnalyticsCartItem | null | undefined) => {
 
       removeItem(item.id)
     },
-    [currency, item, removeItem]
+    [code, item, removeItem]
   )
 
   return {

--- a/src/sdk/cart/validate.ts
+++ b/src/sdk/cart/validate.ts
@@ -61,13 +61,24 @@ export const validateCart = async <Item extends CartItem>(cart: Cart<Item>) => {
     },
   })
 
+  const mappedItems = cart.items.reduce((acc, item) => {
+    acc[item.id] = item
+
+    return acc
+  }, {} as Record<string, Item>)
+
   return (
     validated && {
       id: validated.order.orderNumber,
-      items: validated.order.acceptedOffer.map((item) => ({
-        ...item,
-        id: getItemId(item),
-      })),
+      items: validated.order.acceptedOffer.map((item): Item => {
+        const id = getItemId(item)
+
+        return {
+          ...(mappedItems[id] ?? {}),
+          ...item,
+          id,
+        }
+      }),
       messages: validated.messages,
     }
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR uses the methods defined on the store sdk related to sending/receiving analytics events, to send the `'remove_from_cart' `event. This event is triggered every time a product is removed from the shopping cart, and then received by an analytics provider that stores the data. The data that is sent is a merge between the fields required by SAE analytics and by GA4, so it can be used by both.

## How it works? 
The `CartItem` component is called at several points in the code, and it uses the 'item' prop passed to it to render the cart item. The item is usually obtained via the `useCart()` (which in turn comes from the `useSDKCart()`), and it contains all the data stored _in the cart_ for that specific item. This means that after an item is added to the cart, its removal will only access the user's cart, and not the item database (which is used to add the item to the cart in the first place). Therefore, the cart stores the item with fewer data than available in the database, so adjustments are necessary to obtain the data that needs to be sent to the analytics. This is implemented as follows:
- When the user adds an item to the cart, the mutate query sent to the server will be triggered with only the allowed fields for the mutation.
- On the client side (indexed DB), however, we will store all the cart attributes (after validated and mutated) + some extra attributes that we'll access later to retrieve the analytics relevant data.
- When the user removes the item from the cart, we check the locally stored data for the item to get all the attributes we need, and trigger the sending of the analytics event.

The remaining process happens as any other event such as in #53 :
The attributes are sent as an analytics event, which then is listened by the AnalyticsHandler and inserted in the `window.dataLayer` array to be consumed by the Analytics service (GA4 or SAE).

## How to test it?
`yarn test`. New tests added on `analytics.test.js`, covering:

- The analytics event is added when clicking on the remove button for any product in the cart
- The `remove_from_cart` analytics event is sent with at least the minimum required attributes.
- To test it manually, add something into the shopping cart and remove it afterwards. Open the console and check if the `window.dataLayer` array has the correct analytics data for the removed item.

## References
remove_from_cart event documentation:
https://developers.google.com/analytics/devguides/collection/ga4/reference/events#remove_from_cart

A really interesting error that may arise in TypeScript and that took a couple of days to solve:
https://stackoverflow.com/a/56701587
https://stackoverflow.com/a/59363875

Last but not least,
@icazevedo, my TypeScript teacher
