### PR TITLE
Remove non-null assertions and reactivate ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,4 @@
 {
   "extends": "vtex-react/gatsby",
-  "root": true,
-  "rules": {
-    "@typescript-eslint/no-use-before-define": ["off"],
-    "@typescript-eslint/no-non-null-assertion": ["off"]
-  }
+  "root": true
 }

--- a/src/components/product/ProductSummary/ProductSummary.tsx
+++ b/src/components/product/ProductSummary/ProductSummary.tsx
@@ -26,10 +26,19 @@ function ProductSummary({ product, index }: Props) {
     offers: { lowPrice: spotPrice, offers },
   } = product
 
-  const { listPrice, seller } = useMemo(
-    () => offers.find((x) => x.price === spotPrice)!,
-    [spotPrice, offers]
-  )
+  const { listPrice, seller } = useMemo(() => {
+    const lowestPriceOffer = offers.find((x) => x.price === spotPrice)
+
+    if (!lowestPriceOffer) {
+      console.error(
+        'Could not find product offering with the lowest price. Showing the first provided offering.'
+      )
+
+      return offers[0]
+    }
+
+    return lowestPriceOffer
+  }, [spotPrice, offers])
 
   const linkProps = useProductLink({ product, index })
   const image = useImage(img.url, 'product.summary')

--- a/src/components/product/ProductSummary/ProductSummary.tsx
+++ b/src/components/product/ProductSummary/ProductSummary.tsx
@@ -31,7 +31,7 @@ function ProductSummary({ product, index }: Props) {
 
     if (!lowestPriceOffer) {
       console.error(
-        'Could not find product offering with the lowest price. Showing the first provided offering.'
+        'Could not find the lowest price product offer. Showing the first offer provided.'
       )
 
       return offers[0]

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -25,7 +25,7 @@ function ProductGallery({ title }: Props) {
   return (
     <>
       {/* Controls */}
-      {<FacetedFilter facets={data.search.facets} />}
+      <FacetedFilter facets={data.search.facets} />
       <div className="flex items-center justify-between">
         <div>Total Products: {totalCount}</div>
         <Sort />

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -40,7 +40,7 @@ const Page: FC<Props> = (props) => {
     return <div>loading...</div>
   }
 
-  if (serverData.site == null) {
+  if (serverData.site === null) {
     throw new Error('Site metadata is null on the server side.')
   }
 

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -17,6 +17,14 @@ export type Props = PageProps<
   ServerProductPageQueryQueryVariables
 >
 
+export const BrowserProductPageQuery = gql`
+  query BrowserProductPageQuery($locator: [IStoreSelectedFacet!]!) {
+    product(locator: $locator) {
+      ...ProductViewFragment_product
+    }
+  }
+`
+
 const Page: FC<Props> = (props) => {
   const {
     params: { slug },
@@ -32,18 +40,14 @@ const Page: FC<Props> = (props) => {
     return <div>loading...</div>
   }
 
+  if (serverData.site == null) {
+    throw new Error('Site metadata is null on the server side.')
+  }
+
   return (
-    <View {...props} site={serverData.site!} product={browserData.product} />
+    <View {...props} site={serverData.site} product={browserData.product} />
   )
 }
-
-export const BrowserProductPageQuery = gql`
-  query BrowserProductPageQuery($locator: [IStoreSelectedFacet!]!) {
-    product(locator: $locator) {
-      ...ProductViewFragment_product
-    }
-  }
-`
 
 export const serverQuery = graphql`
   query ServerProductPageQuery {

--- a/src/pages/{StoreCollection.slug}/[...].tsx
+++ b/src/pages/{StoreCollection.slug}/[...].tsx
@@ -29,7 +29,7 @@ const useSearchParams = (props: Props): SearchState => {
       return parseSearchState(new URL(href))
     }
 
-    if (storeCollection == null) {
+    if (storeCollection === null) {
       throw new Error('storeCollection is null.')
     }
 

--- a/src/pages/{StoreCollection.slug}/[...].tsx
+++ b/src/pages/{StoreCollection.slug}/[...].tsx
@@ -29,8 +29,12 @@ const useSearchParams = (props: Props): SearchState => {
       return parseSearchState(new URL(href))
     }
 
+    if (storeCollection == null) {
+      throw new Error('storeCollection is null.')
+    }
+
     // Runs on SSG
-    const { selectedFacets } = storeCollection!.meta
+    const { selectedFacets } = storeCollection.meta
     const [base] = pathname.split(selectedFacets[0].value)
 
     return {

--- a/src/pages/{StoreProduct.slug}/p.tsx
+++ b/src/pages/{StoreProduct.slug}/p.tsx
@@ -21,7 +21,11 @@ function Page(props: Props) {
     return <div>loading...</div>
   }
 
-  return <View {...props} site={site!} product={product} />
+  if (site == null) {
+    throw new Error('Site metadata is null.')
+  }
+
+  return <View {...props} site={site} product={product} />
 }
 
 export const query = graphql`

--- a/src/pages/{StoreProduct.slug}/p.tsx
+++ b/src/pages/{StoreProduct.slug}/p.tsx
@@ -21,7 +21,7 @@ function Page(props: Props) {
     return <div>loading...</div>
   }
 
-  if (site == null) {
+  if (site === null) {
     throw new Error('Site metadata is null.')
   }
 

--- a/src/sdk/cart/useBuyButton.ts
+++ b/src/sdk/cart/useBuyButton.ts
@@ -28,7 +28,9 @@ export const useBuyButton = (item: AnalyticsCartItem | null) => {
         type: 'add_to_cart',
         data: {
           currency: code as CurrencyCode,
-          value: item.price * item.quantity, // TODO: In the future, we can explore more robust ways of calculating the value (gift items, discounts, etc.).
+          // TODO: In the future, we can explore more robust ways of
+          // calculating the value (gift items, discounts, etc.).
+          value: item.price * item.quantity,
           items: [
             {
               currency: code as CurrencyCode,

--- a/src/sdk/cart/validate.ts
+++ b/src/sdk/cart/validate.ts
@@ -28,6 +28,36 @@ export interface Cart<Item> {
   messages?: CartMessages[]
 }
 
+export const ValidateCartMutation = gql`
+  mutation ValidateCartMutation($cart: IStoreCart!) {
+    validateCart(cart: $cart) {
+      order {
+        orderNumber
+        acceptedOffer {
+          seller {
+            identifier
+          }
+          quantity
+          price
+          listPrice
+          itemOffered {
+            sku
+            name
+            image {
+              url
+              alternateName
+            }
+          }
+        }
+      }
+      messages {
+        text
+        status
+      }
+    }
+  }
+`
+
 export const isGift = (item: CartItem) => item.price === 0
 
 export const getItemId = (
@@ -83,33 +113,3 @@ export const validateCart = async <Item extends CartItem>(cart: Cart<Item>) => {
     }
   )
 }
-
-export const ValidateCartMutation = gql`
-  mutation ValidateCartMutation($cart: IStoreCart!) {
-    validateCart(cart: $cart) {
-      order {
-        orderNumber
-        acceptedOffer {
-          seller {
-            identifier
-          }
-          quantity
-          price
-          listPrice
-          itemOffered {
-            sku
-            name
-            image {
-              url
-              alternateName
-            }
-          }
-        }
-      }
-      messages {
-        text
-        status
-      }
-    }
-  }
-`

--- a/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
@@ -25,6 +25,9 @@ class ErrorBoundary extends Component {
     }
   }
 
+  // We can't accurately type the error here, since it could vary depending on
+  // what caused it. This is not standardized.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public componentDidCatch(error: any, errorInfo: ErrorInfo) {
     console.error(`React Error: ${error.message} ${errorInfo.componentStack}`)
 

--- a/src/sdk/graphql/useLazyQuery.ts
+++ b/src/sdk/graphql/useLazyQuery.ts
@@ -4,19 +4,23 @@ import { request } from './request'
 import { DEFAULT_OPTIONS, getKey } from './useQuery'
 import type { QueryOptions } from './useQuery'
 
-export const useLazyQuery = <Query = any, Variables = any>(
+export const useLazyQuery = <Data, Variables = Record<string, unknown>>(
   operationName: string,
   variables: Variables,
   options?: QueryOptions
 ) => {
-  const response = useSWR<Query | null, any[]>(
+  const response = useSWR<Data | null>(
     getKey(operationName, variables),
     () => null,
     DEFAULT_OPTIONS
   )
 
-  const execute = async (v: Variables) => {
-    const data = await request<Query, Variables>(operationName, v, options)
+  const execute = async (queryVariables: Variables) => {
+    const data = await request<Data, Variables>(
+      operationName,
+      queryVariables,
+      options
+    )
 
     response.mutate(data, false)
   }

--- a/src/sdk/graphql/useQuery.ts
+++ b/src/sdk/graphql/useQuery.ts
@@ -6,8 +6,10 @@ import type { RequestOptions } from './request'
 
 export type QueryOptions = SWRConfiguration & RequestOptions
 
-export const getKey = <V>(operationName: string, variables: V) =>
-  `${operationName}::${JSON.stringify(variables)}`
+export const getKey = <Variables>(
+  operationName: string,
+  variables: Variables
+) => `${operationName}::${JSON.stringify(variables)}`
 
 export const DEFAULT_OPTIONS = {
   errorRetryCount: 3,
@@ -18,13 +20,13 @@ export const DEFAULT_OPTIONS = {
   shouldRetryOnError: true,
 }
 
-export const useQuery = <Query = any, Variables = any>(
+export const useQuery = <Data, Variables = Record<string, unknown>>(
   operationName: string,
   variables: Variables,
   options?: QueryOptions
 ) =>
-  useSWR<Query, any[]>(getKey(operationName, variables), {
-    fetcher: () => request<Query, Variables>(operationName, variables, options),
+  useSWR<Data>(getKey(operationName, variables), {
+    fetcher: () => request<Data, Variables>(operationName, variables, options),
     ...DEFAULT_OPTIONS,
     ...options,
   })

--- a/src/views/collection/Seo/hooks/useMetadata.ts
+++ b/src/views/collection/Seo/hooks/useMetadata.ts
@@ -28,7 +28,7 @@ export const useMetadata = ({
   // According to Google, one should use either noindex or canonical, never both.
   // Also, we generate relative canonicals in the HTML. These will be hydrated to absolute URLs via JS.
   const canonicalTags = useMemo(() => {
-    // We still don't support canonalizing other pagination rather then the first one
+    // We only support canonicalizing the first page for now.
     if (typeof canonical === 'string' && page === 0) {
       return {
         canonical:

--- a/src/views/collection/Seo/hooks/useMetadata.ts
+++ b/src/views/collection/Seo/hooks/useMetadata.ts
@@ -26,7 +26,7 @@ export const useMetadata = ({
   } = useSearch()
 
   // According to Google, one should use either noindex or canonical, never both.
-  // Also, we generate relative canonicals in the HTML. These will be hydrated to absolute URLs via JS
+  // Also, we generate relative canonicals in the HTML. These will be hydrated to absolute URLs via JS.
   const canonicalTags = useMemo(() => {
     // We still don't support canonalizing other pagination rather then the first one
     if (typeof canonical === 'string' && page === 0) {

--- a/src/views/collection/Seo/index.tsx
+++ b/src/views/collection/Seo/index.tsx
@@ -37,8 +37,8 @@ function Seo({
 
   const metadata = useMetadata({
     title,
-    titleTemplate: site.siteMetadata.titleTemplate ?? undefined,
-    description: collectionSeo.description ?? site.siteMetadata.description,
+    titleTemplate: titleTemplate ?? undefined,
+    description: collectionSeo.description ?? description,
     canonical: `/${slug}/`,
   })
 

--- a/src/views/collection/Seo/index.tsx
+++ b/src/views/collection/Seo/index.tsx
@@ -21,11 +21,24 @@ function Seo({
   slug,
   storeCollection: { seo: collectionSeo, breadcrumbList },
 }: Props) {
-  const siteMetadata = site.siteMetadata!
+  if (!site || !site.siteMetadata) {
+    throw new Error(`useMetadata: missing site metadata.`)
+  }
+
+  const { titleTemplate, description } = site.siteMetadata
+
+  if (!titleTemplate) {
+    console.warn(`useMetadata: missing 'titleTemplate' from site metadata.`)
+  }
+
+  if (!description) {
+    console.warn(`useMetadata: missing 'description' from site metadata.`)
+  }
+
   const metadata = useMetadata({
     title,
-    titleTemplate: siteMetadata.titleTemplate!,
-    description: collectionSeo.description || siteMetadata.description!,
+    titleTemplate: site.siteMetadata.titleTemplate ?? undefined,
+    description: collectionSeo.description ?? site.siteMetadata.description,
     canonical: `/${slug}/`,
   })
 

--- a/src/views/home/Seo/hooks/useMetadata.ts
+++ b/src/views/home/Seo/hooks/useMetadata.ts
@@ -6,9 +6,9 @@ import type { Props } from '..'
 
 type Options = Props & { title: string }
 
-type Return = ComponentPropsWithoutRef<typeof GatsbySeo>
-
-export const useMetadata = (props: Options): Return => {
+export const useMetadata = (
+  props: Options
+): ComponentPropsWithoutRef<typeof GatsbySeo> => {
   const { locale } = useSession()
   const {
     location: { pathname, host },
@@ -16,20 +16,33 @@ export const useMetadata = (props: Options): Return => {
     title,
   } = props
 
-  const { siteMetadata } = site!
+  if (!site || !site.siteMetadata) {
+    throw new Error(`useMetadata: missing site metadata.`)
+  }
+
+  const { titleTemplate, description } = site.siteMetadata
+
+  if (!titleTemplate) {
+    console.warn(`useMetadata: missing 'titleTemplate' from site metadata.`)
+  }
+
+  if (!description) {
+    console.warn(`useMetadata: missing 'description' from site metadata.`)
+  }
+
   const siteUrl = `https://${host}${pathname}`
 
   return {
     title,
-    description: siteMetadata!.description!,
-    titleTemplate: siteMetadata!.titleTemplate!,
+    description: site.siteMetadata.description ?? undefined,
+    titleTemplate: site.siteMetadata.titleTemplate ?? undefined,
     language: locale,
     canonical: siteUrl,
     openGraph: {
       type: 'website',
       url: siteUrl,
-      title: siteMetadata!.title!,
-      description: siteMetadata!.description!,
+      title: site.siteMetadata.title ?? undefined,
+      description: site.siteMetadata.description ?? undefined,
     },
   }
 }

--- a/src/views/home/Seo/hooks/useMetadata.ts
+++ b/src/views/home/Seo/hooks/useMetadata.ts
@@ -20,7 +20,11 @@ export const useMetadata = (
     throw new Error(`useMetadata: missing site metadata.`)
   }
 
-  const { titleTemplate, description } = site.siteMetadata
+  const {
+    titleTemplate,
+    description,
+    title: openGraphTitle,
+  } = site.siteMetadata
 
   if (!titleTemplate) {
     console.warn(`useMetadata: missing 'titleTemplate' from site metadata.`)
@@ -30,19 +34,23 @@ export const useMetadata = (
     console.warn(`useMetadata: missing 'description' from site metadata.`)
   }
 
+  if (!openGraphTitle) {
+    console.warn(`useMetadata: missing 'title' from site metadata.`)
+  }
+
   const siteUrl = `https://${host}${pathname}`
 
   return {
     title,
-    description: site.siteMetadata.description ?? undefined,
-    titleTemplate: site.siteMetadata.titleTemplate ?? undefined,
+    description: description ?? undefined,
+    titleTemplate: titleTemplate ?? undefined,
     language: locale,
     canonical: siteUrl,
     openGraph: {
       type: 'website',
       url: siteUrl,
-      title: site.siteMetadata.title ?? undefined,
-      description: site.siteMetadata.description ?? undefined,
+      title: openGraphTitle ?? undefined,
+      description: description ?? undefined,
     },
   }
 }

--- a/src/views/home/index.tsx
+++ b/src/views/home/index.tsx
@@ -27,7 +27,7 @@ function View(props: Props) {
       <Seo {...props} title={title} />
 
       {/* Visual Sections */}
-      <h1 className="absolute top-[-100px]">{title}</h1>
+      <h1>{title}</h1>
     </>
   )
 }

--- a/src/views/product/Seo/hooks/useMetadata.ts
+++ b/src/views/product/Seo/hooks/useMetadata.ts
@@ -12,14 +12,17 @@ export const useMetadata = (options: Options) => {
 
   return useMemo(() => {
     const { product, site, title } = options
-    const siteMetadata = site.siteMetadata!
+    const { siteMetadata } = site
     const {
       seo,
       offers: { lowPrice },
     } = product
 
-    const description = seo.description ?? siteMetadata.description!
-    const pathname = path[path.length - 1] === '/' ? path.slice(0, -1) : path // remove trailing slashes from pathname
+    const description = seo.description ?? siteMetadata?.description
+
+    // Remove trailing slashes from pathname.
+    const pathname = path[path.length - 1] === '/' ? path.slice(0, -1) : path
+
     const canonical =
       host !== undefined ? `https://${host}${pathname}` : pathname
 
@@ -35,7 +38,7 @@ export const useMetadata = (options: Options) => {
       canonical,
       openGraph: {
         type: 'og:product',
-        url: `${siteMetadata.siteUrl}${pathname}`,
+        url: `${siteMetadata?.siteUrl}${pathname}`,
         title,
         description,
         images,

--- a/src/views/product/Seo/hooks/useMetadata.ts
+++ b/src/views/product/Seo/hooks/useMetadata.ts
@@ -20,7 +20,7 @@ export const useMetadata = (options: Options) => {
 
     const description = seo.description ?? siteMetadata?.description
 
-    // Remove trailing slashes from pathname.
+    // Remove trailing slashes from pathname
     const pathname = path[path.length - 1] === '/' ? path.slice(0, -1) : path
 
     const canonical =

--- a/src/views/product/hooks/useProduct.ts
+++ b/src/views/product/hooks/useProduct.ts
@@ -7,6 +7,14 @@ import type {
   BrowserProductQueryQueryVariables,
 } from '@generated/graphql'
 
+export const BrowserProductQuery = gql`
+  query BrowserProductQuery($locator: [IStoreSelectedFacet!]!) {
+    product(locator: $locator) {
+      ...ProductViewFragment_product
+    }
+  }
+`
+
 /**
  * serverProduct data is stale and incomplete (because we SSRed it).
  * Let's use it's value as placeholder while we fetch the rest of the data
@@ -17,15 +25,18 @@ export const useProduct = <T extends Partial<BrowserProductQueryQuery>>(
   fallbackData?: T
 ) => {
   const { channel } = useSession()
-  const variables = useMemo(
-    () => ({
+  const variables = useMemo(() => {
+    if (!channel) {
+      throw new Error(`useProduct: 'channel' from session is 'null'.`)
+    }
+
+    return {
       locator: [
         { key: 'id', value: productID },
-        { key: 'channel', value: channel! },
+        { key: 'channel', value: channel },
       ],
-    }),
-    [channel, productID]
-  )
+    }
+  }, [channel, productID])
 
   return useQuery<
     BrowserProductQueryQuery & T,
@@ -35,11 +46,3 @@ export const useProduct = <T extends Partial<BrowserProductQueryQuery>>(
     revalidateOnMount: true,
   })
 }
-
-export const BrowserProductQuery = gql`
-  query BrowserProductQuery($locator: [IStoreSelectedFacet!]!) {
-    product(locator: $locator) {
-      ...ProductViewFragment_product
-    }
-  }
-`

--- a/src/views/product/index.tsx
+++ b/src/views/product/index.tsx
@@ -24,8 +24,6 @@ function View({ product: serverData, site }: Props) {
   const product = data?.product
   const title = data?.product.seo.title ?? site?.siteMetadata?.title ?? ''
 
-  // useProductPixelEffect({ product: { id: product?.id ?? 'unknown' } })
-
   if (product == null) {
     return null
   }

--- a/src/views/search/Seo/index.tsx
+++ b/src/views/search/Seo/index.tsx
@@ -11,7 +11,26 @@ interface Props {
 
 function Seo({ site, title }: Props) {
   const { locale } = useSession()
-  const { titleTemplate, description } = site.siteMetadata!
+
+  if (!site.siteMetadata) {
+    console.error(`Missing site metadata on search page with title ${title}.`)
+
+    return null
+  }
+
+  const { titleTemplate, description } = site.siteMetadata
+
+  if (!titleTemplate) {
+    console.warn(
+      `Missing 'titleTemplate' in site metadata on search page with title ${title}.`
+    )
+  }
+
+  if (!description) {
+    console.warn(
+      `Missing 'description' in site metadata on search page with title ${title}.`
+    )
+  }
 
   return (
     <GatsbySeo
@@ -19,12 +38,12 @@ function Seo({ site, title }: Props) {
       nofollow={false}
       language={locale}
       title={title}
-      description={description!}
-      titleTemplate={titleTemplate!}
+      description={description ?? ''}
+      titleTemplate={titleTemplate ?? ''}
       openGraph={{
         type: 'website',
         title,
-        description: description!,
+        description: description ?? '',
       }}
       defer
     />


### PR DESCRIPTION
## What's the purpose of this pull request?

To remove all `non-null assertions` found in the code and also turn back on two ESLint rules that are currently deactivated globally:

- `@typescript-eslint/no-use-before-define`
- `@typescript-eslint/no-non-null-assertion`

Also, I tried to remove as many unnecessary `any` types as I could, and now we don't get any warnings or errors when running `yarn lint` 😄 .

## How it works? 

There should be no noticeable change in behavior, apart from extra error handling. To avoid runtime errors, some checks and logs were added in this PR when certain objects or properties are `null`. These cases would trigger a runtime error currently since non-null assertions are being used and these cases are not dealt with.

## How to test it?

In the deploy preview below you should see no change in behavior. If you run `yarn lint` locally on this branch, you get a somewhat clean output:

![Screen Shot 2021-11-17 at 10 05 22](https://user-images.githubusercontent.com/27777263/142206100-3cf1dd63-4e1b-496f-b01f-a4f10fe243ee.png)
