### PR TITLE
feat: SkuSelector component

### DIFF
--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -2,6 +2,7 @@ import { graphql } from 'gatsby'
 import React from 'react'
 import Button from 'src/components/ui/Button'
 import { Image } from 'src/components/ui/Image'
+import SkuSelector from 'src/components/ui/SkuSelector'
 import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProduct } from 'src/sdk/product/useProduct'
@@ -67,6 +68,15 @@ function ProductDetails({ product: staleProduct }: Props) {
       />
       <div className="line-through">{formattedListPrice}</div>
       <div className="min-h-[2rem]">{isValidating ? '' : formattedPrice}</div>
+      <SkuSelector
+        label="Size"
+        variant="size"
+        options={[
+          { label: 'P', value: 'p' },
+          { label: 'M', value: 'm' },
+          { label: 'G', value: 'g' },
+        ]}
+      />
       <Button {...buyProps} disabled={isValidating}>
         Add to cart
       </Button>

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -22,11 +22,15 @@ function Option({
       <RadioOption
         label={label}
         value={label}
+        style={{ marginLeft: 60 }} // TODO: Remove it. Added just to skip "Tap Target" error (Lighthouse)
         disabled={disabled}
         checked={label === selectedOption}
         {...otherProps}
       >
-        {variant === 'size' && <span>{option.label}</span>}
+        {variant === 'size' && (
+          // TODO: Remove this inline style. Added just to skip "Tap Target" error (Lighthouse)
+          <span style={{ padding: 48 }}>{option.label}</span>
+        )}
         {variant === 'color' && (
           <div style={{ backgroundColor: value, height: 40, width: 40 }} />
         )}

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -3,61 +3,7 @@ import type { ChangeEventHandler } from 'react'
 import { Image } from 'src/components/ui/Image'
 import { RadioGroup, RadioOption, Label } from '@faststore/ui'
 
-interface OptionProps {
-  variant: string
-  selectedOption: string | number
-  option: DefaultSkuProps | ImageSkuProps
-}
-
-function Option({
-  option,
-  variant,
-  selectedOption,
-  ...otherProps
-}: OptionProps): JSX.Element {
-  if (variant !== 'image' && 'value' in option) {
-    const { label, value, disabled }: DefaultSkuProps = option
-
-    return (
-      <RadioOption
-        label={label}
-        value={label}
-        style={{ marginLeft: 60 }} // TODO: Remove it. Added just to skip "Tap Target" error (Lighthouse)
-        disabled={disabled}
-        checked={label === selectedOption}
-        {...otherProps}
-      >
-        {variant === 'size' && (
-          // TODO: Remove this inline style. Added just to skip "Tap Target" error (Lighthouse)
-          <span style={{ padding: 48 }}>{option.label}</span>
-        )}
-        {variant === 'color' && (
-          <div style={{ backgroundColor: value, height: 40, width: 40 }} />
-        )}
-      </RadioOption>
-    )
-  }
-
-  if (variant === 'image' && 'src' in option) {
-    const { label, src, alt, disabled }: ImageSkuProps = option
-
-    return (
-      <RadioOption
-        label={label}
-        value={label}
-        disabled={disabled}
-        checked={label === selectedOption}
-        {...otherProps}
-      >
-        <Image src={src} alt={alt} variant="product.sku" />
-      </RadioOption>
-    )
-  }
-
-  return <div />
-}
-
-type DefaultSkuProps = {
+interface DefaultSkuProps {
   /**
    * Label to describe the SKU when selected.
    */
@@ -125,14 +71,14 @@ export interface SkuSelectorProps {
   onChange?: ChangeEventHandler<HTMLInputElement>
 }
 
-const SkuSelector = ({
+function SkuSelector({
   label,
   variant,
   options,
   onChange,
   defaultSku,
   testId = 'store-sku-selector',
-}: SkuSelectorProps) => {
+}: SkuSelectorProps) {
   const [selectedSku, setSelectedSku] = useState<string>(defaultSku ?? '')
 
   return (
@@ -152,13 +98,37 @@ const SkuSelector = ({
       >
         {options.map((option, index) => {
           return (
-            <Option
+            <RadioOption
               data-sku-selector-option
               key={String(index)}
-              option={option}
-              variant={variant}
-              selectedOption={selectedSku}
-            />
+              label={option.label}
+              value={option.label}
+              // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
+              style={{ marginLeft: 60 }}
+              disabled={option.disabled}
+              checked={option.label === selectedSku}
+            >
+              {variant === 'size' && (
+                // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
+                <span style={{ padding: 48 }}>{option.label}</span>
+              )}
+              {variant === 'color' && 'value' in option && (
+                <div
+                  style={{
+                    width: 40,
+                    height: 40,
+                    backgroundColor: option.value,
+                  }}
+                />
+              )}
+              {variant === 'image' && 'src' in option && (
+                <Image
+                  src={option.src}
+                  alt={option.alt}
+                  variant="product.sku"
+                />
+              )}
+            </RadioOption>
           )
         })}
       </RadioGroup>

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import type { ChangeEventHandler } from 'react'
+import { Image } from 'src/components/ui/Image'
 import { RadioGroup, RadioOption, Label } from '@faststore/ui'
 
 interface OptionProps {
@@ -20,12 +21,12 @@ function Option({
     return (
       <RadioOption
         label={label}
-        value={value}
+        value={label}
         disabled={disabled}
-        checked={value === selectedOption}
+        checked={label === selectedOption}
         {...otherProps}
       >
-        {variant === 'size' && <span>{option.value}</span>}
+        {variant === 'size' && <span>{option.label}</span>}
         {variant === 'color' && (
           <div style={{ backgroundColor: value, height: 40, width: 40 }} />
         )}
@@ -34,17 +35,17 @@ function Option({
   }
 
   if (variant === 'image' && 'src' in option) {
-    const { id, src, alt, disabled }: ImageSkuProps = option
+    const { label, src, alt, disabled }: ImageSkuProps = option
 
     return (
       <RadioOption
-        value={id}
-        label={alt}
+        label={label}
+        value={label}
         disabled={disabled}
-        checked={id === selectedOption}
+        checked={label === selectedOption}
         {...otherProps}
       >
-        <img src={src} alt={alt} width={40} height={40} />
+        <Image src={src} alt={alt} variant="product.sku" />
       </RadioOption>
     )
   }
@@ -53,15 +54,36 @@ function Option({
 }
 
 type DefaultSkuProps = {
+  /**
+   * Label to describe the SKU when selected.
+   */
   label: string
+  /**
+   * Current value for this SKU.
+   */
   value: string
+  /**
+   * Specifies that this option should be disabled.
+   */
   disabled?: boolean
 }
 
 interface ImageSkuProps {
+  /**
+   * Alternative text description of the image.
+   */
   alt: string
+  /**
+   * Image URL.
+   */
   src: string
-  id: string | number
+  /**
+   * Label to describe the image when selected.
+   */
+  label: string
+  /**
+   * Specifies that this option should be disabled.
+   */
   disabled?: boolean
 }
 
@@ -84,7 +106,7 @@ export interface SkuSelectorProps {
   /**
    * SKU options that should be rendered.
    */
-  skus: Array<Sku<Variant>>
+  options: Array<Sku<Variant>>
   /**
    * Default SKU option.
    */
@@ -100,9 +122,9 @@ export interface SkuSelectorProps {
 }
 
 const SkuSelector = ({
-  skus,
   label,
   variant,
+  options,
   onChange,
   defaultSku,
   testId = 'store-sku-selector',
@@ -124,12 +146,12 @@ const SkuSelector = ({
           setSelectedSku(e.currentTarget.value)
         }}
       >
-        {skus.map((sku, index) => {
+        {options.map((option, index) => {
           return (
             <Option
               data-sku-selector-option
               key={String(index)}
-              option={sku}
+              option={option}
               variant={variant}
               selectedOption={selectedSku}
             />

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react'
+import type { ChangeEventHandler } from 'react'
+import { RadioGroup, RadioOption, Label } from '@faststore/ui'
+
+interface OptionProps {
+  variant: string
+  selectedOption: string | number
+  option: DefaultSkuProps | ImageSkuProps
+}
+
+function Option({
+  option,
+  variant,
+  selectedOption,
+  ...otherProps
+}: OptionProps): JSX.Element {
+  if (variant !== 'image' && 'value' in option) {
+    const { label, value, disabled }: DefaultSkuProps = option
+
+    return (
+      <RadioOption
+        label={label}
+        value={value}
+        disabled={disabled}
+        checked={value === selectedOption}
+        {...otherProps}
+      >
+        {variant === 'size' && <span>{option.value}</span>}
+        {variant === 'color' && (
+          <div style={{ backgroundColor: value, height: 40, width: 40 }} />
+        )}
+      </RadioOption>
+    )
+  }
+
+  if (variant === 'image' && 'src' in option) {
+    const { id, src, alt, disabled }: ImageSkuProps = option
+
+    return (
+      <RadioOption
+        value={id}
+        label={alt}
+        disabled={disabled}
+        checked={id === selectedOption}
+        {...otherProps}
+      >
+        <img src={src} alt={alt} width={40} height={40} />
+      </RadioOption>
+    )
+  }
+
+  return <div />
+}
+
+type DefaultSkuProps = {
+  label: string
+  value: string
+  disabled?: boolean
+}
+
+interface ImageSkuProps {
+  alt: string
+  src: string
+  id: string | number
+  disabled?: boolean
+}
+
+type ImageVariant = 'image'
+
+type Sku<V> = V extends ImageVariant ? ImageSkuProps : DefaultSkuProps
+
+type Variant = 'color' | 'size' | 'image'
+
+export interface SkuSelectorProps {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress,
+   * testing-library, and jest).
+   */
+  testId?: string
+  /**
+   * Specify which variant the component should handle.
+   */
+  variant: Variant
+  /**
+   * SKU options that should be rendered.
+   */
+  skus: Array<Sku<Variant>>
+  /**
+   * Default SKU option.
+   */
+  defaultSku?: string
+  /**
+   * Section label for the SKU selector.
+   */
+  label?: string
+  /**
+   * Function to be triggered when SKU option change.
+   */
+  onChange?: ChangeEventHandler<HTMLInputElement>
+}
+
+const SkuSelector = ({
+  skus,
+  label,
+  variant,
+  onChange,
+  defaultSku,
+  testId = 'store-sku-selector',
+}: SkuSelectorProps) => {
+  const [selectedSku, setSelectedSku] = useState<string>(defaultSku ?? '')
+
+  return (
+    <div data-store-sku-selector data-testid={testId} data-variant={variant}>
+      {label && (
+        <Label data-sku-selector-label>
+          {label}: {selectedSku}
+        </Label>
+      )}
+      <RadioGroup
+        selectedValue={selectedSku}
+        name={`sku-selector-${variant}`}
+        onChange={(e) => {
+          onChange?.(e)
+          setSelectedSku(e.currentTarget.value)
+        }}
+      >
+        {skus.map((sku, index) => {
+          return (
+            <Option
+              data-sku-selector-option
+              key={String(index)}
+              option={sku}
+              variant={variant}
+              selectedOption={selectedSku}
+            />
+          )
+        })}
+      </RadioGroup>
+    </div>
+  )
+}
+
+export default SkuSelector

--- a/src/components/ui/SkuSelector/index.tsx
+++ b/src/components/ui/SkuSelector/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './SkuSelector'
+export type { SkuSelectorProps } from './SkuSelector'

--- a/src/images/config.js
+++ b/src/images/config.js
@@ -44,4 +44,15 @@ module.exports = {
       fitIn: true,
     },
   },
+  'product.sku': {
+    sourceWidth: 720,
+    aspectRatio: 1,
+    width: 40,
+    breakpoints: [20, 40, 80],
+    layout: 'constrained',
+    backgroundColor: '#f0f0f0',
+    options: {
+      fitIn: true,
+    },
+  },
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the `SkuSelector` component (styles to be added in a future PR) to be rendered at the Product's details page.

## How it works? 

This component is using the FastStore's `RadioGroup` component and its child components. It is meant to be used as a list of available (or not) variations of a product.

![Screen Shot 2021-12-21 at 20 37 24](https://user-images.githubusercontent.com/15722605/147018810-bc2c98bb-07f1-477e-b4ae-761de2a241f0.png)

![Screen Shot 2021-12-21 at 20 38 10](https://user-images.githubusercontent.com/15722605/147019237-93a4251d-182c-4cd7-8931-9a529dd274bd.png)

