### PR TITLE
Feat: Style Buttons

### DIFF
--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -77,10 +77,74 @@ function ProductDetails({ product: staleProduct }: Props) {
           { label: 'G', value: 'g' },
         ]}
       />
-      <Button {...buyProps} disabled={isValidating}>
-        Add to cart
-      </Button>
+      {/* NOTE: A loading skeleton had to be used to avoid a Lighthouse's
+      non-composited animation violation due to the button transitioning its
+      background coloe when changing from its initial disabled to active state.
+      See https://web.dev/non-composited-animations/. */}
+      {isValidating ? (
+        <AddToCartLoadingSkeleton />
+      ) : (
+        <Button {...buyProps}>Add to cart</Button>
+      )}
     </div>
+  )
+}
+
+function AddToCartLoadingSkeleton() {
+  // Generated via https://skeletonreact.com/.
+  return (
+    <svg
+      role="img"
+      width="112"
+      height="48"
+      aria-labelledby="loading-aria"
+      viewBox="0 0 112 48"
+      preserveAspectRatio="none"
+    >
+      <title id="loading-aria">Loading...</title>
+      <rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        clipPath="url(#clip-path)"
+        style={{ fill: 'url("#fill")' }}
+      />
+      <defs>
+        <clipPath id="clip-path">
+          <rect x="0" y="0" rx="2" ry="2" width="112" height="48" />
+        </clipPath>
+        <linearGradient id="fill">
+          <stop offset="0.599964" stopColor="#f3f3f3" stopOpacity="1">
+            <animate
+              attributeName="offset"
+              values="-2; -2; 1"
+              keyTimes="0; 0.25; 1"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+          <stop offset="1.59996" stopColor="#ecebeb" stopOpacity="1">
+            <animate
+              attributeName="offset"
+              values="-1; -1; 2"
+              keyTimes="0; 0.25; 1"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+          <stop offset="2.59996" stopColor="#f3f3f3" stopOpacity="1">
+            <animate
+              attributeName="offset"
+              values="0; 0; 3"
+              keyTimes="0; 0.25; 1"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+        </linearGradient>
+      </defs>
+    </svg>
   )
 }
 

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -80,7 +80,7 @@ function ProductDetails({ product: staleProduct }: Props) {
       {/* NOTE: A loading skeleton had to be used to avoid a Lighthouse's
       non-composited animation violation due to the button transitioning its
       background coloe when changing from its initial disabled to active state.
-      See https://web.dev/non-composited-animations/. */}
+      See full explanation on commit https://git.io/JyXV5. */}
       {isValidating ? (
         <AddToCartLoadingSkeleton />
       ) : (

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -79,7 +79,7 @@ function ProductDetails({ product: staleProduct }: Props) {
       />
       {/* NOTE: A loading skeleton had to be used to avoid a Lighthouse's
       non-composited animation violation due to the button transitioning its
-      background coloe when changing from its initial disabled to active state.
+      background color when changing from its initial disabled to active state.
       See full explanation on commit https://git.io/JyXV5. */}
       {isValidating ? (
         <AddToCartLoadingSkeleton />

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -6,19 +6,20 @@ import type { ButtonProps } from '@faststore/ui'
 import './buttons.scss'
 
 type Variant = 'primary' | 'secondary'
+type IconPosition = 'left' | 'right'
 
 type Props = ButtonProps & {
   variant?: Variant
   inverse?: boolean
-  iconLeft?: ReactNode
-  iconRight?: ReactNode
+  icon?: ReactNode
+  iconPosition?: IconPosition
 }
 
 function Button({
   variant,
   inverse,
-  iconLeft,
-  iconRight,
+  icon,
+  iconPosition,
   children,
   ...props
 }: Props) {
@@ -29,9 +30,9 @@ function Button({
       data-button-inverse={inverse}
       {...props}
     >
-      {iconLeft && <UIIcon component={iconLeft} />}
+      {iconPosition === 'left' && <UIIcon component={icon} />}
       {children}
-      {iconRight && <UIIcon component={iconRight} />}
+      {iconPosition === 'right' && <UIIcon component={icon} />}
     </UIButton>
   )
 }

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -4,10 +4,14 @@ import type { ButtonProps } from '@faststore/ui'
 
 import './buttons.scss'
 
-type Props = ButtonProps
+type Props = ButtonProps & {
+  variant?: string
+}
 
-function Button(props: Props) {
-  return <UIButton className="button" {...props} />
+function Button({ variant = '', ...props }: Props) {
+  return (
+    <UIButton className="button" data-button-variant={variant} {...props} />
+  )
 }
 
 export default Button

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from 'react'
 import React from 'react'
-import { Button as UIButton } from '@faststore/ui'
+import { Button as UIButton, Icon as UIIcon } from '@faststore/ui'
 import type { ButtonProps } from '@faststore/ui'
 
 import './buttons.scss'
@@ -8,11 +9,30 @@ type Variant = 'primary' | 'secondary'
 
 type Props = ButtonProps & {
   variant?: Variant
+  inverse?: boolean
+  iconLeft?: ReactNode
+  iconRight?: ReactNode
 }
 
-function Button({ variant, ...props }: Props) {
+function Button({
+  variant,
+  inverse,
+  iconLeft,
+  iconRight,
+  children,
+  ...props
+}: Props) {
   return (
-    <UIButton className="button" data-button-variant={variant} {...props} />
+    <UIButton
+      className="button"
+      data-button-variant={variant}
+      data-button-inverse={inverse}
+      {...props}
+    >
+      {iconLeft && <UIIcon component={iconLeft} />}
+      {children}
+      {iconRight && <UIIcon component={iconRight} />}
+    </UIButton>
   )
 }
 

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import { Button as UIButton } from '@faststore/ui'
 import type { ButtonProps } from '@faststore/ui'
 
+import './buttons.scss'
+
 type Props = ButtonProps
 
 function Button(props: Props) {
-  return <UIButton {...props} />
+  return <UIButton className="button" {...props} />
 }
 
 export default Button

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -4,11 +4,13 @@ import type { ButtonProps } from '@faststore/ui'
 
 import './buttons.scss'
 
+type Variant = 'primary' | 'secondary'
+
 type Props = ButtonProps & {
-  variant?: string
+  variant?: Variant
 }
 
-function Button({ variant = '', ...props }: Props) {
+function Button({ variant, ...props }: Props) {
   return (
     <UIButton className="button" data-button-variant={variant} {...props} />
   )

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,28 +1,31 @@
 .button[data-store-button] {
-  display: flex;
-  align-items: center;
-  padding: var(--space-1)  var(--space-2);
-  color: var(--color-text-negative);
-  background-color: var(--bg-secondary-default);
-  border: 0;
-  border-radius: var(--border-radius-default);
-  svg { margin-right: var(--space-1); }
+  &[data-button-variant="primary"] {
+    display: flex;
+    align-items: center;
+    padding: var(--space-1)  var(--space-2);
+    color: var(--color-text-negative);
+    background-color: var(--bg-secondary-default);
+    border: 0;
+    border-radius: var(--border-radius-default);
+    svg { margin-right: var(--space-1); }
 
-  &:hover, &:focus {
-    background-color: var(--bg-secondary-hover);
-  }
+    &:hover, &:focus {
+      background-color: var(--bg-secondary-hover);
+    }
 
-  &:active {
-    background-color: var(--bg-primary-pressed);
-  }
+    &:active {
+      background-color: var(--bg-primary-pressed);
+    }
 
-  &:focus {
-    outline: 2px solid var(--bg-focus-ring);
-    outline-offset: 1px;
-  }
+    &:focus {
+      outline: 2px solid var(--bg-focus-ring);
+      outline-offset: 1px;
+    }
 
-  &:disabled {
-    color: var(--color-neutral-6);
-    background-color: var(--bg-disabled);
+    &:disabled {
+      color: var(--color-neutral-6);
+      background-color: var(--bg-disabled);
+      cursor: not-allowed;
+    }
   }
 }

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -19,7 +19,7 @@
 
   &[data-button-variant="primary"] {
     padding: var(--space-1)  var(--space-2);
-    color: var(--color-text-negative);
+    color: var(--color-text-inverse);
     background-color: var(--bg-secondary-default);
 
     &:hover, &:focus { background-color: var(--bg-secondary-hover); }
@@ -58,7 +58,7 @@
     }
 
     &[data-button-inverse] {
-      color: var(--color-text-negative);
+      color: var(--color-text-inverse);
       border-color: var(--color-border-light);
       &:hover, &:focus { background-color: var(--bg-secondary-hover); }
       &:active { background-color: var(--bg-secondary-pressed); }

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,3 +1,5 @@
+@import "../../../styles/utilities";
+
 .button[data-store-button] {
   &[data-button-variant="primary"] {
     display: flex;
@@ -18,8 +20,7 @@
     }
 
     &:focus {
-      outline: 2px solid var(--bg-focus-ring);
-      outline-offset: 1px;
+      @include focus-ring;
     }
 
     &:disabled {

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -47,9 +47,9 @@
     background-color: transparent;
     border: 2px solid var(--bg-secondary-default);
 
-    &:hover, &:focus { background-color: var(--color-secondary-0); }
+    &:hover, &:focus { background-color: var(--bg-darken-hover); }
 
-    &:active { background-color: var(--color-secondary-1); }
+    &:active { background-color: var(--bg-darken-pressed); }
 
     &:disabled {
       color: var(--color-neutral-6);
@@ -60,8 +60,8 @@
     &[data-button-inverse] {
       color: var(--color-text-inverse);
       border-color: var(--color-border-light);
-      &:hover, &:focus { background-color: var(--bg-secondary-hover); }
-      &:active { background-color: var(--bg-secondary-pressed); }
+      &:hover, &:focus { background-color: var(--bg-lighten-hover); }
+      &:active { background-color: var(--bg-lighten-pressed); }
     }
   }
 }

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,0 +1,28 @@
+.button[data-store-button] {
+  display: flex;
+  align-items: center;
+  padding: var(--space-1)  var(--space-2);
+  color: var(--color-text-negative);
+  background-color: var(--bg-secondary-default);
+  border: 0;
+  border-radius: var(--border-radius-default);
+  svg { margin-right: var(--space-1); }
+
+  &:hover, &:focus {
+    background-color: var(--bg-secondary-hover);
+  }
+
+  &:active {
+    background-color: var(--bg-primary-pressed);
+  }
+
+  &:focus {
+    outline: 2px solid var(--bg-focus-ring);
+    outline-offset: 1px;
+  }
+
+  &:disabled {
+    color: var(--color-neutral-6);
+    background-color: var(--bg-disabled);
+  }
+}

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--space-1)  var(--space-3);
   font-weight: var(--text-weight-bold);
   column-gap: var(--space-2);
   border: 0;
@@ -18,7 +19,6 @@
   }
 
   &[data-button-variant="primary"] {
-    padding: var(--space-1)  var(--space-2);
     color: var(--color-text-inverse);
     background-color: var(--bg-secondary-default);
 
@@ -42,7 +42,6 @@
   }
 
   &[data-button-variant="secondary"] {
-    padding: var(--space-1)  var(--space-2);
     color: var(--color-text-display);
     background-color: transparent;
     border: 2px solid var(--bg-secondary-default);

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,32 +1,67 @@
 @import "../../../styles/utilities";
 
 .button[data-store-button] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: var(--text-weight-bold);
+  column-gap: var(--space-2);
+  border: 0;
+  border-radius: var(--border-radius-default);
+  transition: background-color .5s ease;
+
+  &:focus { @include focus-ring; }
+
+  &:disabled {
+    cursor: not-allowed;
+    svg { color: var(--color-neutral-5); }
+  }
+
   &[data-button-variant="primary"] {
-    display: flex;
-    align-items: center;
     padding: var(--space-1)  var(--space-2);
     color: var(--color-text-negative);
     background-color: var(--bg-secondary-default);
-    border: 0;
-    border-radius: var(--border-radius-default);
-    svg { margin-right: var(--space-1); }
 
-    &:hover, &:focus {
-      background-color: var(--bg-secondary-hover);
-    }
+    &:hover, &:focus { background-color: var(--bg-secondary-hover); }
 
-    &:active {
-      background-color: var(--bg-primary-pressed);
-    }
-
-    &:focus {
-      @include focus-ring;
-    }
+    &:active { background-color: var(--bg-secondary-pressed); }
 
     &:disabled {
       color: var(--color-neutral-6);
       background-color: var(--bg-disabled);
-      cursor: not-allowed;
+    }
+
+    &[data-button-inverse] {
+      color: var(--color-text-display);
+      background-color: var(--bg-neutral-lightest);
+
+      &:hover, &:focus { background-color: var(--color-secondary-0); }
+
+      &:active { background-color: var(--color-secondary-1); }
+    }
+  }
+
+  &[data-button-variant="secondary"] {
+    padding: var(--space-1)  var(--space-2);
+    color: var(--color-text-display);
+    background-color: transparent;
+    border: 2px solid var(--bg-secondary-default);
+
+    &:hover, &:focus { background-color: var(--color-secondary-0); }
+
+    &:active { background-color: var(--color-secondary-1); }
+
+    &:disabled {
+      color: var(--color-neutral-6);
+      background-color: var(--bg-disabled);
+      border: 0;
+    }
+
+    &[data-button-inverse] {
+      color: var(--color-text-negative);
+      border-color: var(--color-border-light);
+      &:hover, &:focus { background-color: var(--bg-secondary-hover); }
+      &:active { background-color: var(--bg-secondary-pressed); }
     }
   }
 }

--- a/src/components/ui/BuyButton/BuyButton.tsx
+++ b/src/components/ui/BuyButton/BuyButton.tsx
@@ -9,7 +9,7 @@ type Props = ButtonProps
 
 function BuyButton({ children, ...props }: Props) {
   return (
-    <UIButton className="button button__buy" {...props}>
+    <UIButton className="button" data-store-buy-button {...props}>
       <ShoppingCartIcon size="18" weight="bold" />
       {children}
     </UIButton>

--- a/src/components/ui/BuyButton/BuyButton.tsx
+++ b/src/components/ui/BuyButton/BuyButton.tsx
@@ -3,12 +3,14 @@ import { Button as UIButton } from '@faststore/ui'
 import type { ButtonProps } from '@faststore/ui'
 import { ShoppingCart as ShoppingCartIcon } from 'phosphor-react'
 
+import './buy-button.scss'
+
 type Props = ButtonProps
 
 function BuyButton({ children, ...props }: Props) {
   return (
-    <UIButton {...props}>
-      <ShoppingCartIcon />
+    <UIButton className="button button__buy" {...props}>
+      <ShoppingCartIcon size="18" weight="bold" />
       {children}
     </UIButton>
   )

--- a/src/components/ui/BuyButton/buy-button.scss
+++ b/src/components/ui/BuyButton/buy-button.scss
@@ -8,7 +8,7 @@
 
   &:hover { background-color: var(--bg-primary-hover); }
 
-  &:visited { background-color: var(--bg-primary-pressed); }
+  &:active { background-color: var(--bg-primary-pressed); }
 
   &:disabled {
     color: var(--color-neutral-6);

--- a/src/components/ui/BuyButton/buy-button.scss
+++ b/src/components/ui/BuyButton/buy-button.scss
@@ -3,7 +3,7 @@
 .button__buy[data-store-button] {
   padding-right: var(--space-3);
   padding-left: var(--space-3);
-  color: var(--color-text-negative);
+  color: var(--color-text-inverse);
   background-color: var(--bg-primary-default);
 
   &:hover { background-color: var(--bg-primary-hover); }

--- a/src/components/ui/BuyButton/buy-button.scss
+++ b/src/components/ui/BuyButton/buy-button.scss
@@ -1,8 +1,6 @@
 @import "../Button/buttons";
 
-.button__buy[data-store-button] {
-  padding-right: var(--space-3);
-  padding-left: var(--space-3);
+.button[data-store-buy-button] {
   color: var(--color-text-inverse);
   background-color: var(--bg-primary-default);
 

--- a/src/components/ui/BuyButton/buy-button.scss
+++ b/src/components/ui/BuyButton/buy-button.scss
@@ -1,0 +1,17 @@
+@import "../Button/buttons";
+
+.button__buy[data-store-button] {
+  padding-right: var(--space-3);
+  padding-left: var(--space-3);
+  color: var(--color-text-negative);
+  background-color: var(--bg-primary-default);
+
+  &:hover { background-color: var(--bg-primary-hover); }
+
+  &:visited { background-color: var(--bg-primary-pressed); }
+
+  &:disabled {
+    color: var(--color-neutral-6);
+    background-color: var(--bg-disabled);
+  }
+}

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -4,12 +4,12 @@ import { Button as UIButton } from '@faststore/ui'
 import { BellRinging as BellRingingIcon } from 'phosphor-react'
 import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
+import BuyButton from 'src/components/ui/BuyButton'
 
 import SkuSelector from '../components/ui/SkuSelector'
 import Link from '../components/ui/Link'
 import Alert from '../components/ui/Alert'
 import DiscountBadge from '../components/ui/DiscountBadge'
-import Button from '../components/ui/Button'
 import SearchInput from '../components/common/SearchInput'
 
 import '../styles/pattern-library.scss'
@@ -27,6 +27,21 @@ function Page() {
 
           <LinksSection />
 
+          <section className="grid-section grid-content">
+            <h2 className="title-subsection">Custom Button – BuyButton</h2>
+            <ul className="list-horizontal">
+              <li>
+                <BuyButton>Buy Now</BuyButton>
+              </li>
+              <li>
+                <BuyButton disabled>Buy Now</BuyButton>
+              </li>
+              <li>
+                <UIButton>Call to Action</UIButton>
+              </li>
+            </ul>
+          </section>
+
           <InputsSection />
 
           <SkuSelectorSection />
@@ -36,20 +51,6 @@ function Page() {
           <BadgesSection />
 
           <CartToggleSection />
-
-          <section className="grid-section grid-content">
-            <h2 className="title-subsection">Custom Button – Primary</h2>
-            <ul className="list-horizontal">
-              <li>
-                <Button variant="primary">Add to Cart</Button>
-              </li>
-              <li>
-                <Button variant="primary" disabled>
-                  Add to Cart
-                </Button>
-              </li>
-            </ul>
-          </section>
         </main>
       </div>
     </>

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react'
 import { GatsbySeo } from 'gatsby-plugin-next-seo'
 import { Button as UIButton } from '@faststore/ui'
-import { BellRinging as BellRingingIcon } from 'phosphor-react'
+import {
+  BellRinging as BellRingingIcon,
+  ArrowRight as ArrowRightIcon,
+} from 'phosphor-react'
 import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
 import BuyButton from 'src/components/ui/BuyButton'
+import Button from 'src/components/ui/Button'
 
 import SkuSelector from '../components/ui/SkuSelector'
 import Link from '../components/ui/Link'
@@ -36,8 +40,73 @@ function Page() {
               <li>
                 <BuyButton disabled>Buy Now</BuyButton>
               </li>
+            </ul>
+          </section>
+
+          <section className="grid-section grid-content">
+            <h2 className="title-subsection">Custom Button – Primary</h2>
+            <ul className="list-horizontal">
               <li>
-                <UIButton>Call to Action</UIButton>
+                <Button
+                  variant="primary"
+                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                >
+                  Call To Action
+                </Button>
+              </li>
+              <li>
+                <Button
+                  variant="primary"
+                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                  disabled
+                >
+                  Call To Action
+                </Button>
+              </li>
+            </ul>
+            <ul className="list-horizontal dark">
+              <li>
+                <Button
+                  variant="primary"
+                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                  inverse
+                >
+                  Call To Action
+                </Button>
+              </li>
+            </ul>
+          </section>
+
+          <section className="grid-section grid-content">
+            <h2 className="title-subsection">Custom Button – Secondary</h2>
+            <ul className="list-horizontal">
+              <li>
+                <Button
+                  variant="secondary"
+                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                >
+                  Call To Action
+                </Button>
+              </li>
+              <li>
+                <Button
+                  variant="secondary"
+                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                  disabled
+                >
+                  Call To Action
+                </Button>
+              </li>
+            </ul>
+            <ul className="list-horizontal dark">
+              <li>
+                <Button
+                  variant="secondary"
+                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                  inverse
+                >
+                  Call To Action
+                </Button>
               </li>
             </ul>
           </section>

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -6,10 +6,10 @@ import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
 
 import SkuSelector from '../components/ui/SkuSelector'
-import BuyButton from '../components/ui/BuyButton'
 import Link from '../components/ui/Link'
 import Alert from '../components/ui/Alert'
 import DiscountBadge from '../components/ui/DiscountBadge'
+import Button from '../components/ui/Button'
 import SearchInput from '../components/common/SearchInput'
 
 import '../styles/pattern-library.scss'
@@ -27,8 +27,6 @@ function Page() {
 
           <LinksSection />
 
-          <ButtonsSection />
-
           <InputsSection />
 
           <SkuSelectorSection />
@@ -38,6 +36,20 @@ function Page() {
           <BadgesSection />
 
           <CartToggleSection />
+
+          <section className="grid-section grid-content">
+            <h2 className="title-subsection">Custom Button – Primary</h2>
+            <ul className="list-horizontal">
+              <li>
+                <Button variant="primary">Add to Cart</Button>
+              </li>
+              <li>
+                <Button variant="primary" disabled>
+                  Add to Cart
+                </Button>
+              </li>
+            </ul>
+          </section>
         </main>
       </div>
     </>
@@ -120,25 +132,6 @@ function LinksSection() {
           <Link href="/" inverse>
             Link Inverse
           </Link>
-        </li>
-      </ul>
-    </section>
-  )
-}
-
-function ButtonsSection() {
-  return (
-    <section className="grid-section grid-content">
-      <h2 className="title-subsection">Buttons</h2>
-      <ul className="list-horizontal">
-        <li>
-          <BuyButton>Buy Now</BuyButton>
-        </li>
-        <li>
-          <UIButton>Call to Action</UIButton>
-        </li>
-        <li>
-          <UIButton>Call to Action</UIButton>
         </li>
       </ul>
     </section>

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -43,79 +43,9 @@ function Page() {
             </ul>
           </section>
 
-          <section className="grid-section grid-content">
-            <h2 className="title-subsection">Custom Button – Primary</h2>
-            <ul className="list-horizontal">
-              <li>
-                <Button
-                  variant="primary"
-                  icon={<BellRingingIcon size={18} weight="bold" />}
-                  iconPosition="left"
-                >
-                  Call To Action
-                </Button>
-              </li>
-              <li>
-                <Button
-                  variant="primary"
-                  icon={<BellRingingIcon size={18} weight="bold" />}
-                  iconPosition="left"
-                  disabled
-                >
-                  Call To Action
-                </Button>
-              </li>
-            </ul>
-            <ul className="list-horizontal dark">
-              <li>
-                <Button
-                  variant="primary"
-                  icon={<BellRingingIcon size={18} weight="bold" />}
-                  iconPosition="left"
-                  inverse
-                >
-                  Call To Action
-                </Button>
-              </li>
-            </ul>
-          </section>
+          <CustomButtonPrimary />
 
-          <section className="grid-section grid-content">
-            <h2 className="title-subsection">Custom Button – Secondary</h2>
-            <ul className="list-horizontal">
-              <li>
-                <Button
-                  variant="secondary"
-                  icon={<ArrowRightIcon size={18} weight="bold" />}
-                  iconPosition="right"
-                >
-                  Call To Action
-                </Button>
-              </li>
-              <li>
-                <Button
-                  variant="secondary"
-                  icon={<ArrowRightIcon size={18} weight="bold" />}
-                  iconPosition="right"
-                  disabled
-                >
-                  Call To Action
-                </Button>
-              </li>
-            </ul>
-            <ul className="list-horizontal dark">
-              <li>
-                <Button
-                  variant="secondary"
-                  icon={<ArrowRightIcon size={18} weight="bold" />}
-                  iconPosition="right"
-                  inverse
-                >
-                  Call To Action
-                </Button>
-              </li>
-            </ul>
-          </section>
+          <CustomButtonSecondary />
 
           <InputsSection />
 
@@ -208,6 +138,88 @@ function LinksSection() {
           <Link href="/" inverse>
             Link Inverse
           </Link>
+        </li>
+      </ul>
+    </section>
+  )
+}
+
+function CustomButtonPrimary() {
+  return (
+    <section className="grid-section grid-content">
+      <h2 className="title-subsection">Custom Button – Primary</h2>
+      <ul className="list-horizontal">
+        <li>
+          <Button
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+          >
+            Call To Action
+          </Button>
+        </li>
+        <li>
+          <Button
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+            disabled
+          >
+            Call To Action
+          </Button>
+        </li>
+      </ul>
+      <ul className="list-horizontal dark">
+        <li>
+          <Button
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+            inverse
+          >
+            Call To Action
+          </Button>
+        </li>
+      </ul>
+    </section>
+  )
+}
+
+function CustomButtonSecondary() {
+  return (
+    <section className="grid-section grid-content">
+      <h2 className="title-subsection">Custom Button – Secondary</h2>
+      <ul className="list-horizontal">
+        <li>
+          <Button
+            variant="secondary"
+            icon={<ArrowRightIcon size={18} weight="bold" />}
+            iconPosition="right"
+          >
+            Call To Action
+          </Button>
+        </li>
+        <li>
+          <Button
+            variant="secondary"
+            icon={<ArrowRightIcon size={18} weight="bold" />}
+            iconPosition="right"
+            disabled
+          >
+            Call To Action
+          </Button>
+        </li>
+      </ul>
+      <ul className="list-horizontal dark">
+        <li>
+          <Button
+            variant="secondary"
+            icon={<ArrowRightIcon size={18} weight="bold" />}
+            iconPosition="right"
+            inverse
+          >
+            Call To Action
+          </Button>
         </li>
       </ul>
     </section>

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -49,7 +49,8 @@ function Page() {
               <li>
                 <Button
                   variant="primary"
-                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                  icon={<BellRingingIcon size={18} weight="bold" />}
+                  iconPosition="left"
                 >
                   Call To Action
                 </Button>
@@ -57,7 +58,8 @@ function Page() {
               <li>
                 <Button
                   variant="primary"
-                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                  icon={<BellRingingIcon size={18} weight="bold" />}
+                  iconPosition="left"
                   disabled
                 >
                   Call To Action
@@ -68,7 +70,8 @@ function Page() {
               <li>
                 <Button
                   variant="primary"
-                  iconLeft={<BellRingingIcon size={18} weight="bold" />}
+                  icon={<BellRingingIcon size={18} weight="bold" />}
+                  iconPosition="left"
                   inverse
                 >
                   Call To Action
@@ -83,7 +86,8 @@ function Page() {
               <li>
                 <Button
                   variant="secondary"
-                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                  icon={<ArrowRightIcon size={18} weight="bold" />}
+                  iconPosition="right"
                 >
                   Call To Action
                 </Button>
@@ -91,7 +95,8 @@ function Page() {
               <li>
                 <Button
                   variant="secondary"
-                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                  icon={<ArrowRightIcon size={18} weight="bold" />}
+                  iconPosition="right"
                   disabled
                 >
                   Call To Action
@@ -102,7 +107,8 @@ function Page() {
               <li>
                 <Button
                   variant="secondary"
-                  iconRight={<ArrowRightIcon size={18} weight="bold" />}
+                  icon={<ArrowRightIcon size={18} weight="bold" />}
+                  iconPosition="right"
                   inverse
                 >
                   Call To Action

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -49,7 +49,6 @@
   --bg-disabled: var(--color-neutral-2);
   --bg-focus-ring: var(--color-emphasis);
   --bg-selected-outline: var(--color-emphasis-transparent-80);
-  --bg-darken-hover: rgb(0 0 0 / 5%);
   --bg-success: var(--color-success);
 
   // Borders

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -5,6 +5,11 @@
   --color-emphasis-transparent-80: #8db6fa80;
   --color-visited: #6058ba;
 
+  --color-black-transparent-5: rgb(0 0 0 / 5%);
+  --color-black-transparent-10: rgb(0 0 0 / 10%);
+  --color-white-transparent-10: rgb(0 0 0 / 10%);
+  --color-white-transparent-20: rgb(0 0 0 / 20%);
+
   // Text
   --color-link: var(--color-secondary-2);
   --color-link-visited: var(--color-visited);
@@ -15,17 +20,32 @@
   --color-text-display: var(--color-secondary-4);
   --color-text-subtle: var(--color-neutral-6);
 
-  // Backgrounds
+  // Backgrounds – Light
   --bg-primary-light: var(--color-primary-0);
+
   --bg-secondary-light: var(--color-secondary-0);
+
   --bg-neutral-light: var(--color-neutral-1);
   --bg-neutral-lightest: var(--color-neutral-0);
+
+  // Backgrounds – Dark
+  --bg-secondary-dark: var(--color-secondary-4);
+
+  // Backgrounds – Interations
   --bg-primary-default: var(--color-primary-3);
   --bg-primary-hover: var(--color-primary-2);
   --bg-primary-pressed: var(--color-primary-1);
+
   --bg-secondary-default: var(--color-secondary-4);
   --bg-secondary-hover: var(--color-secondary-3);
   --bg-secondary-pressed: var(--color-secondary-2);
+
+  --bg-darken-hover: var(--color-black-transparent-5);
+  --bg-darken-pressed: var(--color-black-transparent-10);
+
+  --bg-lighten-hover: var(--color-white-transparent-10);
+  --bg-lighten-pressed: var(--color-white-transparent-20);
+
   --bg-disabled: var(--color-neutral-2);
   --bg-focus-ring: var(--color-emphasis);
   --bg-selected-outline: var(--color-emphasis-transparent-80);

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -33,6 +33,7 @@
   --bg-success: var(--color-success);
 
   // Borders
+  --color-border-light: var(--color-neutral-0);
   --color-border-display: var(--color-neutral-3);
   --color-border-input: var(--color-neutral-4);
   --color-border-input-selected: var(--color-secondary-2);

--- a/src/styles/pattern-library.scss
+++ b/src/styles/pattern-library.scss
@@ -22,11 +22,16 @@
       background-color: var(--bg-neutral-lightest);
       border-radius: var(--border-radius-default);
 
+      &:not(:last-child):not(:only-of-type) { margin-bottom: var(--space-3); }
+
+      &.dark { background-color: var(--color-neutral-4); }
+
       &.list-horizontal {
         display: flex;
         gap: var(--space-2);
         align-items: center;
       }
+
       &.list-vertical li:not(:last-child) { margin-bottom: var(--space-2); }
     }
     > .title-subsection { margin-bottom: var(--space-1); }

--- a/src/styles/pattern-library.scss
+++ b/src/styles/pattern-library.scss
@@ -24,7 +24,7 @@
 
       &:not(:last-child):not(:only-of-type) { margin-bottom: var(--space-3); }
 
-      &.dark { background-color: var(--color-neutral-4); }
+      &.dark { background-color: var(--color-neutral-6); }
 
       &.list-horizontal {
         display: flex;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -17,6 +17,8 @@ body {
   font-size: var(--text-size-2);
   font-family: var(--sans-serif);
   letter-spacing: .01em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1, h2, h3, h4, h5, h6, p, ul {

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -10,3 +10,8 @@ $base: 16px !default;
 
   @return #{$rem}rem;
 }
+
+@mixin focus-ring {
+  outline: 2px solid var(--bg-focus-ring);
+  outline-offset: 1px;
+}

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -1,6 +1,9 @@
 // Mixins & functions utilities  //////////////////////////
 
+/* SQ-DISABLE */
 @use "sass:math";
+
+/* SQ-ENABLE */
 
 // Px to rem.
 $base: 16px !default;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -22,7 +22,7 @@ module.exports = {
     'string-no-newline': true,
     'unit-no-unknown': true,
     'custom-property-no-missing-var-function': true,
-    'property-no-unknown': true,
+    'property-no-unknown': null,
     'keyframe-declaration-no-important': true,
     'declaration-block-no-duplicate-custom-properties': true,
     'declaration-block-no-duplicate-properties': true,
@@ -61,6 +61,7 @@ module.exports = {
     'selector-pseudo-class-case': 'lower',
     'selector-pseudo-element-case': 'lower',
     'selector-type-case': 'lower',
+    'at-rule-no-unknown': null,
     'at-rule-name-case': 'lower',
     'at-rule-semicolon-space-before': 'never',
     'at-rule-empty-line-before': [
@@ -77,7 +78,7 @@ module.exports = {
     'scss/operator-no-newline-before': true,
     'scss/operator-no-unspaced': true,
     'scss/selector-no-redundant-nesting-selector': true,
-    'scss/at-rule-no-unknown': true,
+    'scss/at-rule-no-unknown': null,
     'scss/at-import-partial-extension': null,
     'selector-class-pattern':
       '^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$',

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -22,7 +22,7 @@ module.exports = {
     'string-no-newline': true,
     'unit-no-unknown': true,
     'custom-property-no-missing-var-function': true,
-    'property-no-unknown': null,
+    'property-no-unknown': true,
     'keyframe-declaration-no-important': true,
     'declaration-block-no-duplicate-custom-properties': true,
     'declaration-block-no-duplicate-properties': true,
@@ -61,7 +61,6 @@ module.exports = {
     'selector-pseudo-class-case': 'lower',
     'selector-pseudo-element-case': 'lower',
     'selector-type-case': 'lower',
-    'at-rule-no-unknown': null,
     'at-rule-name-case': 'lower',
     'at-rule-semicolon-space-before': 'never',
     'at-rule-empty-line-before': [
@@ -78,7 +77,7 @@ module.exports = {
     'scss/operator-no-newline-before': true,
     'scss/operator-no-unspaced': true,
     'scss/selector-no-redundant-nesting-selector': true,
-    'scss/at-rule-no-unknown': null,
+    'scss/at-rule-no-unknown': true,
     'scss/at-import-partial-extension': null,
     'selector-class-pattern':
       '^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$',


### PR DESCRIPTION
## What's the purpose of this pull request?
Styles our three types of buttons:
- BuyButton
- Primary
- Secondary

## How it works? 
|Type|Image|Video|
|-|-|-|
|BuyButton|![image](https://user-images.githubusercontent.com/11613011/147288668-8ab00564-832d-49e3-b2e7-6c5ec696ca80.png)|https://user-images.githubusercontent.com/11613011/147288232-614e9a16-530a-4efc-9eb3-6697280539bb.mov|
|Primary|![image](https://user-images.githubusercontent.com/11613011/147288760-c6bb2d71-aca7-4fac-bfec-73b3e4a869d9.png)|https://user-images.githubusercontent.com/11613011/147288822-cacef365-25a3-4bd0-9fb9-24a753966bba.mov|
|Secondary|![image](https://user-images.githubusercontent.com/11613011/147289096-845a13ce-f282-427e-aec7-bb2a3662362b.png)|https://user-images.githubusercontent.com/11613011/147289190-3d2467c8-68cf-468e-b2fb-697bdcb6f401.mov|

## How to test it?
You can see it working on the `/pattern-library` page
