### PR TITLE
Feat: Style SKU Selectors

### DIFF
--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -3,6 +3,8 @@ import type { ChangeEventHandler } from 'react'
 import { Image } from 'src/components/ui/Image'
 import { RadioGroup, RadioOption, Label } from '@faststore/ui'
 
+import './sku-selector.scss'
+
 interface DefaultSkuProps {
   /**
    * Label to describe the SKU when selected.
@@ -85,7 +87,7 @@ function SkuSelector({
     <div data-store-sku-selector data-testid={testId} data-variant={variant}>
       {label && (
         <Label data-sku-selector-label>
-          {label}: {selectedSku}
+          {label}: <strong>{selectedSku}</strong>
         </Label>
       )}
       <RadioGroup
@@ -104,22 +106,22 @@ function SkuSelector({
               label={option.label}
               value={option.label}
               // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
-              style={{ marginLeft: 60 }}
               disabled={option.disabled}
               checked={option.label === selectedSku}
             >
               {variant === 'size' && (
                 // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
-                <span style={{ padding: 48 }}>{option.label}</span>
+                <span>{option.label}</span>
               )}
               {variant === 'color' && 'value' in option && (
-                <div
-                  style={{
-                    width: 40,
-                    height: 40,
-                    backgroundColor: option.value,
-                  }}
-                />
+                <span>
+                  <div
+                    data-sku-selector-color
+                    style={{
+                      backgroundColor: option.value,
+                    }}
+                  />
+                </span>
               )}
               {variant === 'image' && 'src' in option && (
                 <Image

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -105,14 +105,10 @@ function SkuSelector({
               key={String(index)}
               label={option.label}
               value={option.label}
-              // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
               disabled={option.disabled}
               checked={option.label === selectedSku}
             >
-              {variant === 'size' && (
-                // TODO: Remove this inline style when we start to styling this component. Added just to skip "Tap Target" error (Lighthouse)
-                <span>{option.label}</span>
-              )}
+              {variant === 'size' && <span>{option.label}</span>}
               {variant === 'color' && 'value' in option && (
                 <span>
                   <div

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -40,6 +40,12 @@
         box-shadow: 0 0 0 1px var(--color-neutral-0), 0 0 0 var(--border-width-3) var(--bg-focus-ring);
       }
 
+      &:hover:not(:disabled) + span {
+        border-color: var(--color-border-input-selected);
+        border-width: var(--border-width-2);
+        box-shadow: inset 0 0 0 var(--border-width-3) var(--color-neutral-0);
+      }
+
       &:checked + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
@@ -65,18 +71,12 @@
           }
         }
       }
-
-      &:hover:not(:disabled) + span {
-        border-color: var(--color-border-input-selected);
-        border-width: var(--border-width-2);
-        box-shadow: inset 0 0 0 var(--border-width-3) var(--color-neutral-0);
-      }
     }
   }
 
   &[data-variant="size"] input {
-    &:checked + span { background-color: var(--bg-secondary-light); }
     &:hover:not(:disabled) + span { background-color: var(--bg-secondary-light); }
+    &:checked + span { background-color: var(--bg-secondary-light); }
   }
 
   &[data-variant="color"] {
@@ -89,7 +89,7 @@
     }
 
     input {
-      &:hover:not(:disabled) + span [data-sku-selector-color] { transform: scale(.95); }
+      &:hover:not(:disabled):not(:checked) + span [data-sku-selector-color] { transform: scale(.95); }
       &:checked + span [data-sku-selector-color] { transform: scale(.85); }
     }
   }

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -1,0 +1,73 @@
+[data-store-sku-selector] {
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--text-size-1);
+  column-gap: var(--space-1);
+
+  [data-sku-selector-label] {
+    width: 100%;
+    margin-bottom: var(--space-3);
+  }
+
+  [data-store-radio-option] {
+    position: relative;
+    width: var(--space-7);
+    height: var(--space-7);
+
+    span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      border: var(--border-width-1) solid var(--color-neutral-7);
+      border-radius: var(--border-radius-default);
+      outline: 0 solid transparent;
+      transition: outline .2s ease, background-color .2s ease;
+    }
+
+    input {
+      position: absolute;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      opacity: 0;
+
+      &:focus-visible + span {
+        border-color: var(--color-border-input-selected);
+        border-width: var(--border-width-2);
+        box-shadow: 0 0 0 1px var(--color-neutral-0), 0 0 0 3px var(--bg-focus-ring);
+      }
+
+      &:checked + span {
+        border-color: var(--color-border-input-selected);
+        border-width: var(--border-width-2);
+        outline: 3px solid var(--bg-selected-outline);
+      }
+
+      &:hover + span {
+        border-color: var(--color-border-input-selected);
+        border-width: var(--border-width-2);
+        box-shadow: inset 0 0 0 3px var(--color-neutral-0);
+      }
+    }
+  }
+
+  &[data-variant="size"] input {
+    &:checked + span { background-color: var(--bg-secondary-light); }
+    &:hover + span { background-color: var(--bg-secondary-light); }
+  }
+
+  &[data-variant="color"] {
+    [data-sku-selector-color] {
+      width: var(--space-6);
+      height: var(--space-6);
+      border-radius: var(--border-radius-small);
+      transform-origin: center center;
+      transition: transform .2s ease;
+    }
+
+    input:hover + span [data-sku-selector-color] { transform: scale(.95); }
+    input:checked + span [data-sku-selector-color] { transform: scale(.85); }
+  }
+}

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -15,12 +15,13 @@
     height: var(--space-7);
 
     span {
+      position: relative;
       display: flex;
       align-items: center;
       justify-content: center;
       width: 100%;
       height: 100%;
-      border: var(--border-width-1) solid var(--color-neutral-7);
+      border: var(--border-width-0) solid var(--color-neutral-7);
       border-radius: var(--border-radius-default);
       outline: 0 solid transparent;
       transition: outline .2s ease, background-color .2s ease;
@@ -36,26 +37,46 @@
       &:focus-visible + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
-        box-shadow: 0 0 0 1px var(--color-neutral-0), 0 0 0 3px var(--bg-focus-ring);
+        box-shadow: 0 0 0 1px var(--color-neutral-0), 0 0 0 var(--border-width-3) var(--bg-focus-ring);
       }
 
       &:checked + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
-        outline: 3px solid var(--bg-selected-outline);
+        outline: var(--border-width-3) solid var(--bg-selected-outline);
       }
 
-      &:hover + span {
+      &:disabled {
+        cursor: not-allowed;
+
+        + span {
+          overflow: hidden;
+          color: var(--color-text-disabled);
+          border-color: var(--color-border-input-disabled);
+
+          &::after {
+            position: absolute;
+            width: var(--border-width-0);
+            height: 160%;
+            background-color: var(--color-border-input-disabled);
+            transform: rotate(45deg);
+            transform-origin: center;
+            content: "";
+          }
+        }
+      }
+
+      &:hover:not(:disabled) + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
-        box-shadow: inset 0 0 0 3px var(--color-neutral-0);
+        box-shadow: inset 0 0 0 var(--border-width-3) var(--color-neutral-0);
       }
     }
   }
 
   &[data-variant="size"] input {
     &:checked + span { background-color: var(--bg-secondary-light); }
-    &:hover + span { background-color: var(--bg-secondary-light); }
+    &:hover:not(:disabled) + span { background-color: var(--bg-secondary-light); }
   }
 
   &[data-variant="color"] {
@@ -67,7 +88,9 @@
       transition: transform .2s ease;
     }
 
-    input:hover + span [data-sku-selector-color] { transform: scale(.95); }
-    input:checked + span [data-sku-selector-color] { transform: scale(.85); }
+    input {
+      &:hover:not(:disabled) + span [data-sku-selector-color] { transform: scale(.95); }
+      &:checked + span [data-sku-selector-color] { transform: scale(.85); }
+    }
   }
 }

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -5,6 +5,7 @@ import { BellRinging } from 'phosphor-react'
 import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
 
+import SkuSelector from '../components/ui/SkuSelector'
 import BuyButton from '../components/ui/BuyButton'
 import Alert from '../components/ui/Alert'
 import DiscountBadge from '../components/ui/DiscountBadge'
@@ -84,6 +85,37 @@ function Page() {
             <ul className="list-horizontal">
               <li style={{ width: '100%' }}>
                 <SearchInput />
+              </li>
+            </ul>
+          </section>
+
+          <section className="grid-section grid-content">
+            <h2 className="title-subsection">SKU Selectors</h2>
+            <ul className="list-vertical">
+              <li>
+                <SkuSelector
+                  label="Size"
+                  variant="size"
+                  options={[
+                    { label: 'S', value: 's' },
+                    { label: 'M', value: 'm' },
+                    { label: 'L', value: 'l' },
+                    { label: 'XL', value: 'xl' },
+                  ]}
+                />
+              </li>
+              <li>
+                <SkuSelector
+                  label="Color"
+                  variant="color"
+                  options={[
+                    { label: 'Yellow', value: '#f1d096' },
+                    { label: 'Pink', value: '#eed0d0' },
+                    { label: 'Green', value: '#b2dbcb' },
+                    { label: 'Blue', value: '#bacbec' },
+                    { label: 'Lilac', value: '#ebdcff' },
+                  ]}
+                />
               </li>
             </ul>
           </section>

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -100,7 +100,7 @@ function Page() {
                     { label: 'S', value: 's' },
                     { label: 'M', value: 'm' },
                     { label: 'L', value: 'l' },
-                    { label: 'XL', value: 'xl' },
+                    { label: 'XL', value: 'xl', disabled: true },
                   ]}
                 />
               </li>
@@ -113,7 +113,7 @@ function Page() {
                     { label: 'Pink', value: '#eed0d0' },
                     { label: 'Green', value: '#b2dbcb' },
                     { label: 'Blue', value: '#bacbec' },
-                    { label: 'Lilac', value: '#ebdcff' },
+                    { label: 'Lilac', value: '#ebdcff', disabled: true },
                   ]}
                 />
               </li>

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -2,6 +2,7 @@
 
 :root {
   --color-emphasis: #8db6fa;
+  --color-emphasis-transparent-80: #8db6fa80;
   --color-visited: #6058ba;
 
   // Text
@@ -24,13 +25,14 @@
   --bg-secondary-pressed: var(--color-secondary-2);
   --bg-disabled: var(--color-neutral-2);
   --bg-focus-ring: var(--color-emphasis);
-  --bg-selected-outline: var(--color-emphasis);
+  --bg-selected-outline: var(--color-emphasis-transparent-80);
   --bg-darken-hover: rgb(0 0 0 / 5%);
   --bg-success: var(--color-success);
 
   // Borders
   --color-border-display: var(--color-neutral-3);
   --color-border-input: var(--color-neutral-4);
+  --color-border-input-selected: var(--color-secondary-2);
   --color-border-input-disabled: var(--color-neutral-6);
 }
 

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -10,6 +10,7 @@
   --color-link-visited: var(--color-visited);
   --color-link-negative: var(--color-neutral-0);
   --color-text: var(--color-neutral-7);
+  --color-text-disabled: var(--color-neutral-6);
   --color-text-negative: var(--color-neutral-0);
 
   // Backgrounds

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -76,6 +76,7 @@
 
   // Radius
   --border-radius-flat: 0;
+  --border-radius-small: .125rem;
   --border-radius-default: .25rem;
   --border-radius-pill: 100px;
   --border-radius-circle: 100%;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -85,6 +85,7 @@
   --border-width-0: 1px;
   --border-width-1: 1.5px;
   --border-width-2: 2px;
+  --border-width-3: 3px;
 
   // Grid ///////////////////////////
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -32,6 +32,7 @@ module.exports = {
     'selector-pseudo-class-no-unknown': true,
     'selector-pseudo-element-no-unknown': true,
     'comment-no-empty': true,
+    'no-descending-specificity': null,
     'no-invalid-position-at-import-rule': true,
     'no-duplicate-at-import-rules': true,
     'no-extra-semicolons': true,


### PR DESCRIPTION
## What's the purpose of this pull request?
Styles our two types (for now) of SKU Selectors:
- Size
- Color

## How it works? 
|Prototype|Image|Video|
|-|-|-|
|![image](https://user-images.githubusercontent.com/11613011/147496707-8c817da2-4f30-4bae-bf24-88cc44554e90.png)|![image](https://user-images.githubusercontent.com/11613011/147496750-3097a25e-4567-4e79-9eb5-bc2c30ed8d8f.png)|https://user-images.githubusercontent.com/11613011/147496628-c4f3e658-3041-49be-9a59-2f92bb616975.mov|

## How to test it?
You can see it working on the `/pattern-library` page
