### PR TITLE
feat: Add search event to Analytics

### DIFF
--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -9,6 +9,11 @@ import { cypress } from '../../store.config'
 
 const { pages } = cypress
 
+beforeEach(() => {
+  cy.clearIDB()
+  cy.log('IDB Cleared')
+})
+
 const dataLayerHasEvent = (eventName) => {
   return cy.window().then((window) => {
     const allEvents = window.dataLayer.map((evt) => evt.name)
@@ -31,10 +36,6 @@ const eventDataHasCurrencyProperty = () => {
 }
 
 describe('add_to_cart event', () => {
-  beforeEach(() => {
-    cy.clearIDB()
-  })
-
   const testAddToCartEvent = (skuId) => {
     cy.window().then((window) => {
       const { dataLayer } = window
@@ -192,10 +193,6 @@ describe('view_item_list event', () => {
 })
 
 describe('search event', () => {
-  beforeEach(() => {
-    cy.clearIDB()
-  })
-
   it('raises search', () => {
     cy.visit(pages.home, options)
     cy.waitForHydration()

--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -190,3 +190,21 @@ describe('view_item_list event', () => {
     })
   })
 })
+
+describe('search event', () => {
+  beforeEach(() => {
+    cy.clearIDB()
+  })
+
+  it('raises search', () => {
+    cy.visit(pages.home, options)
+    cy.waitForHydration()
+
+    cy.getById('store-input').click().type('shirt')
+    cy.getById('store-button')
+      .click()
+      .then(() => {
+        dataLayerHasEvent('search')
+      })
+  })
+})

--- a/src/components/common/Navlinks/Navlinks.tsx
+++ b/src/components/common/Navlinks/Navlinks.tsx
@@ -4,6 +4,10 @@ import Logo from 'src/components/ui/Logo'
 
 const links = [
   {
+    href: '/apparel-and-accessories',
+    name: 'Apparel',
+  },
+  {
     href: '/office',
     name: 'Office',
   },

--- a/src/components/common/Navlinks/Navlinks.tsx
+++ b/src/components/common/Navlinks/Navlinks.tsx
@@ -4,10 +4,6 @@ import Logo from 'src/components/ui/Logo'
 
 const links = [
   {
-    href: '/apparel-and-accesories',
-    name: 'Apparel',
-  },
-  {
     href: '/office',
     name: 'Office',
   },

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -1,6 +1,11 @@
 import './SearchInput.module.css'
 
-import { formatSearchState, initSearchState } from '@faststore/sdk'
+import type { SearchEvent } from '@faststore/sdk'
+import {
+  formatSearchState,
+  initSearchState,
+  sendAnalyticsEvent,
+} from '@faststore/sdk'
 import { SearchInput as UISearchInput } from '@faststore/ui'
 import { navigate } from 'gatsby'
 import React from 'react'
@@ -15,6 +20,11 @@ const doSearch = async (term: string) => {
       base: '/s',
     })
   )
+
+  sendAnalyticsEvent<SearchEvent>({
+    name: 'search',
+    params: { search_term: term },
+  })
 
   navigate(`${pathname}${search}`)
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR intends to add the `search` event to the analytics events layer. 

Ps. This PR is replacing the #97.

## How it works? 
Every time a term is searched in the `SearchInput` component, the `sendAnalyticsEvent` is trigged and the `search` event is added to the dataLayer.
## How to test it?
Tests in `analytics.test.js` file will simulate the steps of a search scenario. Just run `yarn test`. 

## References
GA4 reference about [Search event](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#search)
