### PR TITLE
feat: Style Quantity Selector

### DIFF
--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -7,13 +7,13 @@ import './quantity-selector.scss'
 interface QuantitySelectorProps {
   maxQuantity: number
   minQuantity: number
-  inputDisabled: boolean
+  disabled: boolean
 }
 
 export function QuantitySelector({
   maxQuantity,
   minQuantity,
-  inputDisabled,
+  disabled,
 }: QuantitySelectorProps) {
   const [quantity, setQuantity] = useState<number>(minQuantity)
 
@@ -52,21 +52,21 @@ export function QuantitySelector({
   return (
     <UIQuantitySelector
       quantity={quantity}
-      className={inputDisabled ? 'disabled' : ''}
+      className={disabled ? 'disabled' : ''}
       leftButtonProps={{
         onClick: decrease,
-        disabled: isLeftDisabled() || inputDisabled,
+        disabled: isLeftDisabled() || disabled,
         icon: <MinusIcon size={16} weight="bold" />,
       }}
       rightButtonProps={{
         onClick: increase,
-        disabled: isRightDisabled() || inputDisabled,
+        disabled: isRightDisabled() || disabled,
         icon: <PlusIcon size={16} weight="bold" />,
       }}
       inputProps={{
         onChange: validateInput,
         readOnly: false,
-        disabled: inputDisabled,
+        disabled,
       }}
     />
   )

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -5,17 +5,17 @@ import { Plus as PlusIcon, Minus as MinusIcon } from 'phosphor-react'
 import './quantity-selector.scss'
 
 interface QuantitySelectorProps {
-  maxQuantity: number
-  minQuantity: number
+  max: number
+  min: number
   disabled: boolean
 }
 
 export function QuantitySelector({
-  maxQuantity,
-  minQuantity,
+  max,
+  min,
   disabled,
 }: QuantitySelectorProps) {
-  const [quantity, setQuantity] = useState<number>(minQuantity)
+  const [quantity, setQuantity] = useState<number>(min)
 
   function increase() {
     setQuantity((currentQuantity) =>
@@ -30,15 +30,15 @@ export function QuantitySelector({
   }
 
   function isLeftDisabled(): boolean {
-    return quantity === minQuantity
+    return quantity === min
   }
 
   function isRightDisabled(): boolean {
-    return quantity === maxQuantity
+    return quantity === max
   }
 
   function validateQuantityBounds(n: number): number {
-    return Math.min(Math.max(n, minQuantity), maxQuantity)
+    return Math.min(Math.max(n, min), max)
   }
 
   function validateInput(e: React.FormEvent<HTMLInputElement>) {

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import { QuantitySelector as UIQuantitySelector } from '@faststore/ui'
+import { Plus, Minus } from 'phosphor-react'
+
+import './quantity-selector.scss'
+
+interface QuantitySelectorProps {
+  maxQuantity: number
+  minQuantity: number
+  inputDisabled: boolean
+}
+
+export function QuantitySelector({
+  maxQuantity,
+  minQuantity,
+  inputDisabled,
+}: QuantitySelectorProps) {
+  const [quantity, setQuantity] = useState<number>(minQuantity)
+
+  function increase() {
+    setQuantity((currentQuantity) =>
+      validateQuantityBounds(currentQuantity + 1)
+    )
+  }
+
+  function decrease() {
+    setQuantity((currentQuantity) =>
+      validateQuantityBounds(currentQuantity - 1)
+    )
+  }
+
+  function isLeftDisabled(): boolean {
+    return quantity === minQuantity
+  }
+
+  function isRightDisabled(): boolean {
+    return quantity === maxQuantity
+  }
+
+  function validateQuantityBounds(n: number): number {
+    return Math.min(Math.max(n, minQuantity), maxQuantity)
+  }
+
+  function validateInput(e: React.FormEvent<HTMLInputElement>) {
+    const val = e.currentTarget.value
+
+    if (!Number.isNaN(Number(val))) {
+      setQuantity(validateQuantityBounds(Number(val)))
+    }
+  }
+
+  return (
+    <UIQuantitySelector
+      quantity={quantity}
+      className={inputDisabled ? 'disabled' : ''}
+      leftButtonProps={{
+        onClick: decrease,
+        disabled: isLeftDisabled() || inputDisabled,
+        icon: <Minus size={16} weight="bold" />,
+      }}
+      rightButtonProps={{
+        onClick: increase,
+        disabled: isRightDisabled() || inputDisabled,
+        icon: <Plus size={16} weight="bold" />,
+      }}
+      inputProps={{
+        onChange: validateInput,
+        readOnly: false,
+        disabled: inputDisabled,
+      }}
+    />
+  )
+}
+
+export default QuantitySelector

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -56,12 +56,12 @@ export function QuantitySelector({
       leftButtonProps={{
         onClick: decrease,
         disabled: isLeftDisabled() || inputDisabled,
-        icon: <Minus size={16} weight="bold" />,
+        icon: <MinusIcon size={16} weight="bold" />,
       }}
       rightButtonProps={{
         onClick: increase,
         disabled: isRightDisabled() || inputDisabled,
-        icon: <Plus size={16} weight="bold" />,
+        icon: <PlusIcon size={16} weight="bold" />,
       }}
       inputProps={{
         onChange: validateInput,

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { QuantitySelector as UIQuantitySelector } from '@faststore/ui'
-import { Plus, Minus } from 'phosphor-react'
+import { Plus as PlusIcon, Minus as MinusIcon } from 'phosphor-react'
 
 import './quantity-selector.scss'
 

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -51,8 +51,8 @@ export function QuantitySelector({
 
   return (
     <UIQuantitySelector
+      data-store-quantity-selector={disabled ? 'disabled' : 'true'}
       quantity={quantity}
-      className={disabled ? 'disabled' : ''}
       leftButtonProps={{
         onClick: decrease,
         disabled: isLeftDisabled() || disabled,

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -16,6 +16,8 @@ export function QuantitySelector({
   disabled,
 }: QuantitySelectorProps) {
   const [quantity, setQuantity] = useState<number>(min)
+  const isLeftDisabled = quantity === min
+  const isRightDisabled = quantity === max
 
   function increase() {
     setQuantity((currentQuantity) =>
@@ -27,14 +29,6 @@ export function QuantitySelector({
     setQuantity((currentQuantity) =>
       validateQuantityBounds(currentQuantity - 1)
     )
-  }
-
-  function isLeftDisabled(): boolean {
-    return quantity === min
-  }
-
-  function isRightDisabled(): boolean {
-    return quantity === max
   }
 
   function validateQuantityBounds(n: number): number {
@@ -55,12 +49,12 @@ export function QuantitySelector({
       quantity={quantity}
       leftButtonProps={{
         onClick: decrease,
-        disabled: isLeftDisabled() || disabled,
+        disabled: isLeftDisabled || disabled,
         icon: <MinusIcon size={16} weight="bold" />,
       }}
       rightButtonProps={{
         onClick: increase,
-        disabled: isRightDisabled() || disabled,
+        disabled: isRightDisabled || disabled,
         icon: <PlusIcon size={16} weight="bold" />,
       }}
       inputProps={{

--- a/src/components/ui/QuantitySelector/index.tsx
+++ b/src/components/ui/QuantitySelector/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './QuantitySelector'

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -61,15 +61,14 @@
     }
   }
 
-  &[data-store-quantity-selector="disabled"] {
-    background-color: var(--bg-disabled);
-    border-color: var(--bg-disabled);
-    box-shadow: 0 0 0 var(--border-width-0) var(--bg-disabled);
-
-    [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
-  }
-
   &:hover:not([data-store-quantity-selector="disabled"]) {
     box-shadow: 0 0 0 var(--border-width-2) var(--color-border-input-selected);
   }
+}
+
+[data-store-quantity-selector="disabled"] {
+  background-color: var(--bg-disabled);
+  box-shadow: 0 0 0 var(--border-width-0) var(--bg-disabled);
+
+  [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
 }

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -42,12 +42,12 @@
     }
   }
 
-  &.disabled {
+  &[data-store-quantity-selector="disabled"] {
     background-color: var(--bg-disabled);
     outline-color: var(--bg-disabled);
   }
 
-  &:hover:not(.disabled) {
+  &:hover:not([data-store-quantity-selector="disabled"]) {
     outline: var(--border-width-2) solid var(--color-border-input-selected);
   }
 }

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -6,8 +6,9 @@
   width: 8.125rem;
   height: var(--space-7);
   background-color: var(--bg-neutral-lightest);
-  border: var(--border-width-0) solid var(--color-border-input);
   border-radius: var(--border-radius-default);
+  box-shadow: 0 0 0 var(--border-width-0) var(--color-border-input);
+  transition: box-shadow .2s ease;
 
   [data-store-icon] {
     margin: 0;
@@ -27,27 +28,48 @@
   }
 
   [data-quantity-selector-button] {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     width: 100%;
     height: 100%;
-    padding: 0;
+    padding: var(--space-0);
     background-color: transparent;
-    border-color: transparent;
+    border: 0;
+    border-radius: var(--border-radius-default);
+
+    [data-store-icon] {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      border-radius: var(--border-radius-default);
+      transition: background-color .2s ease;
+    }
+
+    &:hover:not(:disabled) [data-store-icon] { background-color: var(--bg-secondary-light); }
 
     &:disabled {
       cursor: not-allowed;
       [data-store-icon] { color: var(--color-border-input-disabled); }
+    }
+
+    &:focus-visible {
+      outline: none;
+
+      [data-store-icon] {
+        box-shadow: inset 0 0 0 var(--border-width-2) var(--color-border-input-selected);
+      }
     }
   }
 
   &[data-store-quantity-selector="disabled"] {
     background-color: var(--bg-disabled);
     border-color: var(--bg-disabled);
+    box-shadow: 0 0 0 var(--border-width-0) var(--bg-disabled);
+
+    [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
   }
 
   &:hover:not([data-store-quantity-selector="disabled"]) {
-    border: var(--border-width-2) solid var(--color-border-input-selected);
+    box-shadow: 0 0 0 var(--border-width-2) var(--color-border-input-selected);
   }
 }

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   width: 8.125rem;
   height: var(--space-7);
-  background-color: var(--color-neutral-0);
+  background-color: var(--bg-neutral-lightest);
   border-radius: var(--border-radius-default);
   outline: var(--border-width-0) solid var(--color-border-input);
 

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -44,7 +44,7 @@
 
   &.disabled {
     background-color: var(--bg-disabled);
-    outline-color: var(--color-neutral-2);
+    outline-color: var(--bg-disabled);
   }
 
   &:hover:not(.disabled) {

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -6,8 +6,8 @@
   width: 8.125rem;
   height: var(--space-7);
   background-color: var(--bg-neutral-lightest);
+  border: var(--border-width-0) solid var(--color-border-input);
   border-radius: var(--border-radius-default);
-  outline: var(--border-width-0) solid var(--color-border-input);
 
   [data-store-icon] {
     margin: 0;
@@ -44,10 +44,10 @@
 
   &[data-store-quantity-selector="disabled"] {
     background-color: var(--bg-disabled);
-    outline-color: var(--bg-disabled);
+    border-color: var(--bg-disabled);
   }
 
   &:hover:not([data-store-quantity-selector="disabled"]) {
-    outline: var(--border-width-2) solid var(--color-border-input-selected);
+    border: var(--border-width-2) solid var(--color-border-input-selected);
   }
 }

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -1,0 +1,53 @@
+[data-store-quantity-selector] {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 8.125rem;
+  height: var(--space-7);
+  background-color: var(--color-neutral-0);
+  border-radius: var(--border-radius-default);
+  outline: var(--border-width-0) solid var(--color-border-input);
+
+  [data-store-icon] {
+    margin: 0;
+    color: var(--color-border-input-selected);
+    line-height: 0;
+  }
+
+  [data-quantity-selector-input] {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    text-align: center;
+    background-color: transparent;
+    border-width: 0;
+
+    &:focus { outline: 0; }
+  }
+
+  [data-quantity-selector-button] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    background-color: transparent;
+    border-color: transparent;
+
+    &:disabled {
+      cursor: not-allowed;
+      [data-store-icon] { color: var(--color-border-input-disabled); }
+    }
+  }
+
+  &.disabled {
+    background-color: var(--bg-disabled);
+    outline-color: var(--color-neutral-2);
+  }
+
+  &:hover:not(.disabled) {
+    outline: var(--border-width-2) solid var(--color-border-input-selected);
+  }
+}

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -40,7 +40,7 @@
         box-shadow: 0 0 0 1px var(--color-neutral-0), 0 0 0 var(--border-width-3) var(--bg-focus-ring);
       }
 
-      &:hover:not(:disabled) + span {
+      &:hover:not(:disabled):not(:checked) + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
         box-shadow: inset 0 0 0 var(--border-width-3) var(--color-neutral-0);
@@ -49,7 +49,7 @@
       &:checked + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
-        outline: var(--border-width-3) solid var(--bg-selected-outline);
+        box-shadow: 0 0 0 var(--border-width-3) var(--bg-selected-outline);
       }
 
       &:disabled {

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -23,8 +23,8 @@
       height: 100%;
       border: var(--border-width-0) solid var(--color-neutral-7);
       border-radius: var(--border-radius-default);
-      outline: 0 solid transparent;
-      transition: outline .2s ease, background-color .2s ease;
+      box-shadow: 0;
+      transition: box-shadow .2s ease, background-color .2s ease;
     }
 
     input {
@@ -43,7 +43,6 @@
       &:hover:not(:disabled):not(:checked) + span {
         border-color: var(--color-border-input-selected);
         border-width: var(--border-width-2);
-        box-shadow: inset 0 0 0 var(--border-width-3) var(--color-neutral-0);
       }
 
       &:checked + span {

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -11,6 +11,7 @@ import Link from '../components/ui/Link'
 import Alert from '../components/ui/Alert'
 import DiscountBadge from '../components/ui/DiscountBadge'
 import SearchInput from '../components/common/SearchInput'
+import QuantitySelector from '../components/ui/QuantitySelector'
 
 import '../styles/pattern-library.scss'
 

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -148,14 +148,28 @@ function ButtonsSection() {
 
 function InputsSection() {
   return (
-    <section className="grid-section grid-content">
-      <h2 className="title-subsection">Inputs</h2>
-      <ul className="list-horizontal">
-        <li style={{ width: '100%' }}>
-          <SearchInput />
-        </li>
-      </ul>
-    </section>
+    <>
+      <section className="grid-section grid-content">
+        <h2 className="title-subsection">Search Input</h2>
+        <ul className="list-horizontal">
+          <li style={{ width: '100%' }}>
+            <SearchInput />
+          </li>
+        </ul>
+      </section>
+
+      <section className="grid-section grid-content">
+        <h2 className="title-subsection">Quantity Selector Input</h2>
+        <ul className="list-horizontal">
+          <li>
+            <QuantitySelector min={1} max={10} disabled={false} />
+          </li>
+          <li>
+            <QuantitySelector min={4} max={40} disabled />
+          </li>
+        </ul>
+      </section>
+    </>
   )
 }
 

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -1,6 +1,9 @@
 // Mixins & functions utilities  //////////////////////////
 
+/* SQ-DISABLE */
 @use "sass:math";
+
+/* SQ-ENABLE */
 
 // Px to rem.
 $base: 16px !default;


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR styles the Quantity Selector component



## How it works? 
Add a stylesheet for Quantity Selectors and implement a style matching the Figma Prototype:
<img width="1061" alt="Screen Shot 2021-12-28 at 11 52 51" src="https://user-images.githubusercontent.com/24229855/147578469-fefb6d8e-1dbd-4cca-a6d7-c493b715f838.png">

**NOTE:** The _error_ and _focus_ styles were not implemented in this PR, but will be addressed in future versions.


## How to test it?
Open `base.store` locally and access `/pattern-library`. Scroll to the Quantity Selector section to see the styled component.
<img width="354" alt="Screen Shot 2021-12-28 at 11 59 13" src="https://user-images.githubusercontent.com/24229855/147579064-5e6abc41-2c36-4630-826a-ff319fe38638.png">

## References
Had some problems with focus and focus-visible. Both have the same behavior even when specifying different styles to each one. _Apparently_, it is not working for inputs, only for buttons.
https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible

Many thanks to @renatamottam
