### PR TITLE
fix: Rename SkuSelector's 'size' variant to 'label'

### DIFF
--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -70,7 +70,7 @@ function ProductDetails({ product: staleProduct }: Props) {
       <div className="min-h-[2rem]">{isValidating ? '' : formattedPrice}</div>
       <SkuSelector
         label="Size"
-        variant="size"
+        variant="label"
         options={[
           { label: 'P', value: 'p' },
           { label: 'M', value: 'm' },

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -43,7 +43,7 @@ type ImageVariant = 'image'
 
 type Sku<V> = V extends ImageVariant ? ImageSkuProps : DefaultSkuProps
 
-type Variant = 'color' | 'size' | 'image'
+type Variant = 'color' | 'label' | 'image'
 
 export interface SkuSelectorProps {
   /**
@@ -101,14 +101,13 @@ function SkuSelector({
         {options.map((option, index) => {
           return (
             <RadioOption
-              data-sku-selector-option
               key={String(index)}
               label={option.label}
               value={option.label}
               disabled={option.disabled}
               checked={option.label === selectedSku}
             >
-              {variant === 'size' && <span>{option.label}</span>}
+              {variant === 'label' && <span>{option.label}</span>}
               {variant === 'color' && 'value' in option && (
                 <span>
                   <div

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -74,7 +74,7 @@
     }
   }
 
-  &[data-variant="size"] input {
+  &[data-variant="label"] input {
     &:hover:not(:disabled) + span { background-color: var(--bg-secondary-light); }
     &:checked + span { background-color: var(--bg-secondary-light); }
   }

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -95,7 +95,7 @@ function Page() {
               <li>
                 <SkuSelector
                   label="Size"
-                  variant="size"
+                  variant="label"
                   options={[
                     { label: 'S', value: 's' },
                     { label: 'M', value: 'm' },


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to rename the SkuSelector's `size` variant to `label` to keep it more generic.