### PR TITLE
chore: adds general updates to `main-styled`

### DIFF
--- a/src/components/cart/CartToggle/CartToggle.tsx
+++ b/src/components/cart/CartToggle/CartToggle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Button from 'src/components/ui/Button'
 import { useCartToggleButton } from 'src/sdk/cart/useCartToggleButton'
-import { ShoppingCart } from 'phosphor-react'
+import { ShoppingCart as ShoppingCartIcon } from 'phosphor-react'
 
 import './cart-toggle.scss'
 
@@ -14,7 +14,7 @@ function CartToggle() {
       className="cart-toggle"
       aria-label={`Cart with ${btnProps['data-items']} items`}
     >
-      <ShoppingCart size={32} />
+      <ShoppingCartIcon size={32} />
     </Button>
   )
 }

--- a/src/components/cart/CartToggle/cart-toggle.scss
+++ b/src/components/cart/CartToggle/cart-toggle.scss
@@ -13,7 +13,7 @@
     justify-content: center;
     min-width: var(--space-4);
     padding: 1px var(--space-0);
-    color: var(--color-link-inverse);
+    color: var(--color-text-inverse);
     font-weight: var(--text-weight-bold);
     font-size: var(--text-size-0);
     background: var(--bg-secondary-default);

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -3,7 +3,7 @@ import { SearchInput as UISearchInput } from '@faststore/ui'
 import { navigate } from 'gatsby'
 import React from 'react'
 import type { SearchInputProps as UISearchInputProps } from '@faststore/ui'
-import { MagnifyingGlass } from 'phosphor-react'
+import { MagnifyingGlass as MagnifyingGlassIcon } from 'phosphor-react'
 
 import './search-input.scss'
 
@@ -23,7 +23,7 @@ const doSearch = async (term: string) => {
 function SearchInput(props: SearchInputProps) {
   return (
     <UISearchInput
-      icon={<MagnifyingGlass />}
+      icon={<MagnifyingGlassIcon />}
       placeholder="Search everything at the store"
       onSubmit={doSearch}
       {...props}

--- a/src/components/sections/BannerText/banner-text.scss
+++ b/src/components/sections/BannerText/banner-text.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/vendors/include-media.scss";
+@import "../../../styles/vendors/include-media";
 
 [data-store-banner] {
   padding: var(--space-6) var(--space-5);
@@ -6,7 +6,7 @@
   background-color: var(--color-secondary-4);
 
   @include media(">=notebook") {
-    padding: var(--space-9) 273px;
+    padding: var(--space-9) 17.06rem;
   }
 
   [data-store-banner-content] {

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -6,7 +6,7 @@ import UIHero, {
   HeroLink,
 } from 'src/components/ui/Hero'
 import Image from 'src/components/ui/Image/Image'
-import { ArrowRight } from 'phosphor-react'
+import { ArrowRight as ArrowRightIcon } from 'phosphor-react'
 
 interface HeroProps {
   title: string
@@ -37,7 +37,7 @@ const Hero = ({
           </div>
           <HeroLink>
             <Link to={link}>
-              {linkText} <ArrowRight size={24} />
+              {linkText} <ArrowRightIcon size={24} />
             </Link>
           </HeroLink>
         </div>

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Alert as UIAlert, Icon as UIIcon } from '@faststore/ui'
 import type { AlertProps } from '@faststore/ui'
 import Button from 'src/components/ui/Button'
-import { X } from 'phosphor-react'
+import { X as XIcon } from 'phosphor-react'
 import { Link } from 'gatsby'
 
 import './alert.scss'
@@ -49,7 +49,7 @@ function Alert({
 
       {dismissible && (
         <Button data-alert-button aria-label="Close" onClick={handleClose}>
-          <X size={18} weight="bold" />
+          <XIcon size={18} weight="bold" />
         </Button>
       )}
     </UIAlert>

--- a/src/components/ui/Hero/hero.scss
+++ b/src/components/ui/Hero/hero.scss
@@ -13,7 +13,7 @@
   [data-store-hero-content] {
     width: 100%;
     padding: var(--space-6) var(--space-4);
-    color: var(--color-link-inverse);
+    color: var(--color-text-inverse);
 
     @include media(">=notebook") {
       padding: var(--space-13) var(--space-9) var(--space-13) 0;

--- a/src/components/ui/Hero/hero.scss
+++ b/src/components/ui/Hero/hero.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/vendors/include-media.scss";
+@import "../../../styles/vendors/include-media";
 
 [data-store-hero] {
   display: flex;

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/vendors/include-media.scss";
+@import "../../../styles/vendors/include-media";
 
 [data-store-link] {
   min-width: auto;

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { GatsbySeo } from 'gatsby-plugin-next-seo'
 import { Button as UIButton } from '@faststore/ui'
-import { BellRinging } from 'phosphor-react'
+import { BellRinging as BellRingingIcon } from 'phosphor-react'
 import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
 
@@ -203,7 +203,7 @@ function AlertsSection() {
       <h2 className="title-subsection">Alerts</h2>
       <ul className="list-vertical">
         <li>
-          <Alert icon={<BellRinging size={24} />}>
+          <Alert icon={<BellRingingIcon size={24} />}>
             Get 10% off today:&nbsp;<span>NEW10</span>
           </Alert>
         </li>
@@ -215,7 +215,7 @@ function AlertsSection() {
         <li>
           {showAlert1 ? (
             <Alert
-              icon={<BellRinging size={24} />}
+              icon={<BellRingingIcon size={24} />}
               dismissible
               onClose={() => setShowAlert1(false)}
             >
@@ -230,7 +230,7 @@ function AlertsSection() {
         <li>
           {showAlert2 ? (
             <Alert
-              icon={<BellRinging size={24} />}
+              icon={<BellRingingIcon size={24} />}
               dismissible
               link={{ to: '#alerts', text: 'Action' }}
               onClose={() => setShowAlert2(false)}
@@ -247,7 +247,7 @@ function AlertsSection() {
         <li>
           {showAlert3 ? (
             <Alert
-              icon={<BellRinging size={24} />}
+              icon={<BellRingingIcon size={24} />}
               dismissible
               link={{ to: '#alerts', text: 'Action' }}
               onClose={() => setShowAlert3(false)}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -2,7 +2,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap");
 
 // Output functions & mixins
-@import "vendors/include-media";
+@import "scaffold";
 
 // Resets //////////////////////////
 @import "resets/modern-normalize";

--- a/src/styles/scaffold.scss
+++ b/src/styles/scaffold.scss
@@ -1,0 +1,7 @@
+// Scaffold  //////////////////////////
+
+// Vendors
+@import "vendors/include-media";
+
+// Output functions & mixins
+@import "utilities";

--- a/src/styles/utilities.scss
+++ b/src/styles/utilities.scss
@@ -1,0 +1,12 @@
+// Mixins & functions utilities  //////////////////////////
+
+@use "sass:math";
+
+// Px to rem.
+$base: 16px !default;
+
+@function rem($size) {
+  $rem: math.div($size, $base);
+
+  @return #{$rem}rem;
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

- Updates icons import from phosphor lib
- Fixes some stylesheets syntax issues
- Adds `px to rem` function
- Creates `scaffold.scss` file. Maybe we could import this file whenever we need to use `include media` or `px to rem` function. I don't like this approach but I couldn't find a work around for now.

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em> 

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
