### PR TITLE
feat(ui): Add Breadcrumb

### DIFF
--- a/@generated/graphql/index.ts
+++ b/@generated/graphql/index.ts
@@ -3559,6 +3559,13 @@ export type ProductDetailsFragment_ProductFragment = {
       seller: { identifier: string }
     }>
   }
+  breadcrumbList: {
+    itemListElement: Array<{
+      item: string
+      name: string
+      position: number
+    }>
+  }
 }
 
 export type ProductGalleryQueryQueryVariables = Exact<{

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -7,6 +7,7 @@ import { useBuyButton } from 'src/sdk/cart/useBuyButton'
 import { useFormattedPrice } from 'src/sdk/product/useFormattedPrice'
 import { useProduct } from 'src/sdk/product/useProduct'
 import type { ProductDetailsFragment_ProductFragment } from '@generated/graphql'
+import Breadcrumb from 'src/components/ui/Breadcrumb'
 
 interface Props {
   product: ProductDetailsFragment_ProductFragment
@@ -34,8 +35,11 @@ function ProductDetails({ product: staleProduct }: Props) {
       offers: {
         offers: [{ price, listPrice, seller }],
       },
+      breadcrumbList,
     },
   } = data
+
+  const breadcrumbs = breadcrumbList ?? staleProduct.breadcrumbList
 
   const formattedPrice = useFormattedPrice(price)
   const formattedListPrice = useFormattedPrice(listPrice)
@@ -59,6 +63,7 @@ function ProductDetails({ product: staleProduct }: Props) {
 
   return (
     <div>
+      <Breadcrumb breadcrumbList={breadcrumbs.itemListElement} />
       <h2>{variantName}</h2>
       <Image
         src={img.url}
@@ -176,6 +181,14 @@ export const fragment = graphql`
         seller {
           identifier
         }
+      }
+    }
+
+    breadcrumbList {
+      itemListElement {
+        item
+        name
+        position
       }
     }
   }

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -14,6 +14,12 @@ export interface BreadcrumbProps extends UIBreadcrumbProps {
 }
 
 function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
+  const buildUrl = (url: string) => {
+    const parsedUrl = url.split('/')
+
+    return `/${parsedUrl[parsedUrl.length - 1]}`
+  }
+
   return (
     <UIBreadcrumb divider={divider}>
       <Link aria-label="home" href="/">
@@ -22,9 +28,9 @@ function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
 
       {breadcrumbList.map(({ item, name }, index) => {
         return breadcrumbList.length === index + 1 ? (
-          <span>{name}</span>
+          <span key={String(index)}>{name}</span>
         ) : (
-          <Link href={item} key={String(index)}>
+          <Link href={buildUrl(item)} key={String(index)}>
             {name}
           </Link>
         )

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Breadcrumb as UIBreadcrumb } from '@faststore/ui'
+import Link from 'src/components/ui/Link'
+import type { BreadcrumbProps as UIBreadcrumbProps } from '@faststore/ui'
+import { House as HouseIcon } from 'phosphor-react'
+
+export interface BreadcrumbProps extends UIBreadcrumbProps {
+  breadcrumbList: Array<{
+    item: string
+    name: string
+    position: number
+  }>
+}
+
+function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
+  return (
+    <UIBreadcrumb divider={divider}>
+      <Link href="/">
+        <HouseIcon />
+      </Link>
+
+      {breadcrumbList.map(({ item, name, position }, index) => {
+        return breadcrumbList.length === index + 1 ? (
+          <span>{name}</span>
+        ) : (
+          <Link href={item} key={String(index)}>
+            {name}
+          </Link>
+        )
+      })}
+    </UIBreadcrumb>
+  )
+}
+
+export default Breadcrumb

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -4,22 +4,23 @@ import Link from 'src/components/ui/Link'
 import type { BreadcrumbProps as UIBreadcrumbProps } from '@faststore/ui'
 import { House as HouseIcon } from 'phosphor-react'
 
+type ItemElement = {
+  item: string
+  name: string
+  position: number
+}
 export interface BreadcrumbProps extends UIBreadcrumbProps {
-  breadcrumbList: Array<{
-    item: string
-    name: string
-    position: number
-  }>
+  breadcrumbList: ItemElement[]
 }
 
 function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
   return (
     <UIBreadcrumb divider={divider}>
-      <Link href="/">
+      <Link aria-label="home" href="/">
         <HouseIcon />
       </Link>
 
-      {breadcrumbList.map(({ item, name, position }, index) => {
+      {breadcrumbList.map(({ item, name }, index) => {
         return breadcrumbList.length === index + 1 ? (
           <span>{name}</span>
         ) : (

--- a/src/components/ui/Breadcrumb/index.tsx
+++ b/src/components/ui/Breadcrumb/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Breadcrumb'


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR intends to add the basic structure of the **Breadcrumb** component to the Base Store (styling will be covered in a future PR). For prioritization concerns, this PR will also not implement the extra links (`...` link), this will be tackled in a future PR.

![image](https://user-images.githubusercontent.com/10616243/147693772-13bce9e2-aa37-4fab-b6e5-2f94eb450059.png)

## How it works? 
The component will basically `map` the items in the **breadcrumbList** to render them as `Links`
![image](https://user-images.githubusercontent.com/10616243/147694193-9ec8d8a9-30f5-4556-b0c9-46b6cf43cce1.png)

## How to test it?
The component is displayed in the PDP page, and it can be tested by accessing the links in the breadcrumb.
