### PR TITLE
style: Add sigin link styles

### DIFF
--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -5,6 +5,7 @@ import Logo from 'src/components/ui/Logo'
 import Link from 'src/components/ui/Link'
 import Button from 'src/components/ui/Button'
 import { List as ListIcon, X as XIcon } from 'phosphor-react'
+import SignInLink from 'src/components/ui/SignInLink'
 
 import SearchInput from '../SearchInput'
 
@@ -45,6 +46,7 @@ function Navbar() {
             <Logo />
           </LinkGatsby>
           <div className="navbar__buttons">
+            <SignInLink />
             <CartToggle />
           </div>
           <SearchInput />

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -78,6 +78,9 @@ function Navbar() {
               </Link>
             ))}
           </nav>
+          <div className="navlinks__signin">
+            <SignInLink />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -67,6 +67,19 @@
       }
     }
   }
+
+  .navlinks__signin {
+    margin-top: var(--space-2);
+    padding-top: var(--space-2);
+    border-top: var(--border-width-0) solid var(--color-neutral-2);
+
+    @include media(">=notebook") { display: none; }
+
+    .signin-link[data-button-signin-link] {
+      width: fit-content;
+      padding-left: 0;
+    }
+  }
 }
 
 .navbar__row {
@@ -95,7 +108,17 @@
   align-items: center;
   justify-content: flex-end;
 
-  @include media(">=notebook") { order: 2; }
+  .signin-link[data-button-signin-link] {
+    display: none;
+  }
+
+  @include media(">=notebook") {
+    order: 2;
+
+    .signin-link[data-button-signin-link] {
+      display: inline-flex;
+    }
+  }
 }
 
 .navbar__header {

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -5,15 +5,17 @@ import type { ButtonProps } from '@faststore/ui'
 
 import './buttons.scss'
 
-type Variant = 'primary' | 'secondary'
-type IconPosition = 'left' | 'right'
+export type Variant = 'primary' | 'secondary' | 'tertiary'
+export type IconPosition = 'left' | 'right'
 
-type Props = ButtonProps & {
+export type UIButtonProps = {
   variant?: Variant
   inverse?: boolean
   icon?: ReactNode
   iconPosition?: IconPosition
 }
+
+type Props = ButtonProps & UIButtonProps
 
 function Button({
   variant,

--- a/src/components/ui/Button/LinkButton.tsx
+++ b/src/components/ui/Button/LinkButton.tsx
@@ -1,0 +1,44 @@
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import React from 'react'
+import { Icon as UIIcon, Link } from '@faststore/ui'
+
+import './buttons.scss'
+
+type Variant = 'primary' | 'secondary'
+type IconPosition = 'left' | 'right'
+
+type Props = {
+  variant?: Variant
+  inverse?: boolean
+  icon?: ReactNode
+  iconPosition?: IconPosition
+  disabled?: boolean
+} & AnchorHTMLAttributes<HTMLAnchorElement>
+
+function LinkButton({
+  variant,
+  inverse,
+  icon,
+  iconPosition,
+  children,
+  disabled = false,
+  className,
+  ...otherProps
+}: Props) {
+  return (
+    <Link
+      data-store-button
+      className={`button ${className}`}
+      data-button-variant={variant}
+      data-button-inverse={inverse}
+      data-button-disabled={disabled}
+      {...otherProps}
+    >
+      {iconPosition === 'left' && <UIIcon component={icon} />}
+      {children}
+      {iconPosition === 'right' && <UIIcon component={icon} />}
+    </Link>
+  )
+}
+
+export default LinkButton

--- a/src/components/ui/Button/LinkButton.tsx
+++ b/src/components/ui/Button/LinkButton.tsx
@@ -1,19 +1,15 @@
-import type { AnchorHTMLAttributes, ReactNode } from 'react'
 import React from 'react'
-import { Icon as UIIcon, Link } from '@faststore/ui'
+import type { LinkProps } from '@faststore/ui'
+import { Icon as UIIcon, Link as UILink } from '@faststore/ui'
+
+import type { UIButtonProps } from './Button'
 
 import './buttons.scss'
 
-type Variant = 'primary' | 'secondary'
-type IconPosition = 'left' | 'right'
-
 type Props = {
-  variant?: Variant
-  inverse?: boolean
-  icon?: ReactNode
-  iconPosition?: IconPosition
   disabled?: boolean
-} & AnchorHTMLAttributes<HTMLAnchorElement>
+} & UIButtonProps &
+  LinkProps<'a'>
 
 function LinkButton({
   variant,
@@ -22,13 +18,13 @@ function LinkButton({
   iconPosition,
   children,
   disabled = false,
-  className,
+  className = '',
   ...otherProps
 }: Props) {
   return (
-    <Link
+    <UILink
       data-store-button
-      className={`button ${className}`}
+      className={`link-button ${className}`}
       data-button-variant={variant}
       data-button-inverse={inverse}
       data-button-disabled={disabled}
@@ -37,7 +33,7 @@ function LinkButton({
       {iconPosition === 'left' && <UIIcon component={icon} />}
       {children}
       {iconPosition === 'right' && <UIIcon component={icon} />}
-    </Link>
+    </UILink>
   )
 }
 

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -78,7 +78,7 @@
     }
 
     &:disabled, &[data-button-disabled="true"] {
-      color: var(--color-neutral-6);
+      color: var(--color-text-disabled);
       background-color: var(--bg-disabled);
     }
 

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -17,7 +17,6 @@
 
   &:disabled, &[data-button-disabled="true"] {
     cursor: not-allowed;
-    pointer-events: none;
     svg { color: var(--color-neutral-5); }
   }
 
@@ -78,7 +77,7 @@
     }
 
     &:disabled, &[data-button-disabled="true"] {
-      color: var(--color-text-disabled);
+      color: var(--color-neutral-6);
       background-color: var(--bg-disabled);
     }
 
@@ -86,7 +85,7 @@
       color: var(--color-text-display);
       background-color: var(--bg-neutral-lightest);
 
-      &:hover, &:focus { background-color: var(--bg-secondary-light); }
+      &:hover, &:focus { background-color: var(--color-secondary-0); }
 
       &:active { background-color: var(--color-secondary-1); }
     }
@@ -98,7 +97,7 @@
     text-decoration: none;
   }
 
-  &:disabled, &[data-button-disabled="true"] {
+  &[data-button-disabled="true"] {
     pointer-events: none;
   }
 }

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/utilities";
 
-.button[data-store-button] {
+.button[data-store-button], .link-button[data-store-button] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -19,14 +19,6 @@
     cursor: not-allowed;
     pointer-events: none;
     svg { color: var(--color-neutral-5); }
-  }
-
-  &:hover {
-    text-decoration: none;
-  }
-
-  &:visited {
-    color: inherit;
   }
 
   &[data-button-variant="primary"] {
@@ -73,5 +65,40 @@
       &:hover, &:focus { background-color: var(--bg-lighten-hover); }
       &:active { background-color: var(--bg-lighten-pressed); }
     }
+  }
+
+  &[data-button-variant="tertiary"] {
+    color: var(--color-link);
+
+    &:hover, &:focus { background-color: var(--bg-secondary-light); }
+
+    &:active {
+      color: var(--color-text-display);
+      background-color: var(--color-secondary-1);
+    }
+
+    &:disabled, &[data-button-disabled="true"] {
+      color: var(--color-neutral-6);
+      background-color: var(--bg-disabled);
+    }
+
+    &[data-button-inverse] {
+      color: var(--color-text-display);
+      background-color: var(--bg-neutral-lightest);
+
+      &:hover, &:focus { background-color: var(--color-secondary-0); }
+
+      &:active { background-color: var(--color-secondary-1); }
+    }
+  }
+}
+
+.link-button[data-store-button] {
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:disabled, &[data-button-disabled="true"] {
+    pointer-events: none;
   }
 }

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -1,11 +1,13 @@
 @import "../../../styles/utilities";
 
 .button[data-store-button] {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-height: var(--min-size);
   padding: var(--space-1)  var(--space-3);
   font-weight: var(--text-weight-bold);
+  text-decoration: none;
   column-gap: var(--space-2);
   border: 0;
   border-radius: var(--border-radius-default);
@@ -13,9 +15,18 @@
 
   &:focus { @include focus-ring; }
 
-  &:disabled {
+  &:disabled, &[data-button-disabled="true"] {
     cursor: not-allowed;
+    pointer-events: none;
     svg { color: var(--color-neutral-5); }
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: inherit;
   }
 
   &[data-button-variant="primary"] {
@@ -26,7 +37,7 @@
 
     &:active { background-color: var(--bg-secondary-pressed); }
 
-    &:disabled {
+    &:disabled, &[data-button-disabled="true"] {
       color: var(--color-neutral-6);
       background-color: var(--bg-disabled);
     }
@@ -50,7 +61,7 @@
 
     &:active { background-color: var(--bg-darken-pressed); }
 
-    &:disabled {
+    &:disabled, &[data-button-disabled="true"] {
       color: var(--color-neutral-6);
       background-color: var(--bg-disabled);
       border: 0;

--- a/src/components/ui/Button/buttons.scss
+++ b/src/components/ui/Button/buttons.scss
@@ -86,7 +86,7 @@
       color: var(--color-text-display);
       background-color: var(--bg-neutral-lightest);
 
-      &:hover, &:focus { background-color: var(--color-secondary-0); }
+      &:hover, &:focus { background-color: var(--bg-secondary-light); }
 
       &:active { background-color: var(--color-secondary-1); }
     }

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Button'
+export { default as LinkButton } from './LinkButton'

--- a/src/components/ui/SignInLink/SignInLink.tsx
+++ b/src/components/ui/SignInLink/SignInLink.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { User as UserIcon } from 'phosphor-react'
+
+import { LinkButton } from '../Button'
+
+const SignInLink: React.FC = () => {
+  return (
+    <LinkButton
+      href="/"
+      className="title-sub-subsection"
+      data-button-variant="primary"
+      data-button-inverse="true"
+    >
+      <UserIcon size={32} />
+      <span>Sign In</span>
+    </LinkButton>
+  )
+}
+
+export default SignInLink

--- a/src/components/ui/SignInLink/SignInLink.tsx
+++ b/src/components/ui/SignInLink/SignInLink.tsx
@@ -11,7 +11,7 @@ const SignInLink: React.FC = () => {
       className="title-sub-subsection signin-link"
       variant="tertiary"
     >
-      <UserIcon size={24} />
+      <UserIcon size={18} weight="bold" />
       <span>Sign In</span>
     </LinkButton>
   )

--- a/src/components/ui/SignInLink/SignInLink.tsx
+++ b/src/components/ui/SignInLink/SignInLink.tsx
@@ -6,12 +6,12 @@ import { LinkButton } from '../Button'
 const SignInLink: React.FC = () => {
   return (
     <LinkButton
+      data-button-signin-link
       href="/"
-      className="title-sub-subsection"
-      data-button-variant="primary"
-      data-button-inverse="true"
+      className="title-sub-subsection signin-link"
+      variant="tertiary"
     >
-      <UserIcon size={32} />
+      <UserIcon size={24} />
       <span>Sign In</span>
     </LinkButton>
   )

--- a/src/components/ui/SignInLink/index.ts
+++ b/src/components/ui/SignInLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SignInLink'

--- a/src/pages/pattern-library.tsx
+++ b/src/pages/pattern-library.tsx
@@ -8,7 +8,8 @@ import CartToggle from 'src/components/cart/CartToggle'
 import { CartProvider, UIProvider } from '@faststore/sdk'
 import Tiles, { Tile } from 'src/components/ui/Tiles'
 import BuyButton from 'src/components/ui/BuyButton'
-import Button from 'src/components/ui/Button'
+import Button, { LinkButton } from 'src/components/ui/Button'
+import SignInLink from 'src/components/ui/SignInLink'
 
 import SkuSelector from '../components/ui/SkuSelector'
 import Link from '../components/ui/Link'
@@ -38,6 +39,8 @@ function Page() {
 
           <CustomButtonSecondary />
 
+          <CustomLinkButtonPrimary />
+
           <InputsSection />
 
           <SkuSelectorSection />
@@ -49,6 +52,8 @@ function Page() {
           <BadgesSection />
 
           <CartToggleSection />
+
+          <SignInLinkSection />
         </main>
       </div>
     </>
@@ -229,6 +234,50 @@ function CustomButtonSecondary() {
           >
             Call To Action
           </Button>
+        </li>
+      </ul>
+    </section>
+  )
+}
+
+function CustomLinkButtonPrimary() {
+  return (
+    <section className="grid-section grid-content">
+      <h2 className="title-subsection">Custom Link Button – Primary</h2>
+      <ul className="list-horizontal">
+        <li>
+          <LinkButton
+            href="/"
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+          >
+            Call To Action
+          </LinkButton>
+        </li>
+        <li>
+          <LinkButton
+            href="/"
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+            disabled
+          >
+            Call To Action
+          </LinkButton>
+        </li>
+      </ul>
+      <ul className="list-horizontal dark">
+        <li>
+          <LinkButton
+            href="/"
+            variant="primary"
+            icon={<BellRingingIcon size={18} weight="bold" />}
+            iconPosition="left"
+            inverse
+          >
+            Call To Action
+          </LinkButton>
         </li>
       </ul>
     </section>
@@ -441,6 +490,19 @@ function CartToggleSection() {
           </ul>
         </CartProvider>
       </UIProvider>
+    </section>
+  )
+}
+
+function SignInLinkSection() {
+  return (
+    <section className="grid-section grid-content">
+      <h2 className="title-subsection">Sign In Link</h2>
+      <ul className="list-horizontal">
+        <li>
+          <SignInLink />
+        </li>
+      </ul>
     </section>
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR styles the SignInLink component

## How it works? 
Add a stylesheet for SignInLink and implement a style like the [Figma Prototype](https://www.figma.com/file/wS0Kek1aSzIRl20jdtnSsL/Alpha-Version?node-id=0%3A1)

![Screen Shot 2021-12-29 at 18 03 03](https://user-images.githubusercontent.com/51174217/147703210-76b2b51e-8444-40dd-802f-26f0e9f35a8e.png)

