### PR TITLE
Style breadcrumb style

### DIFF
--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -63,7 +63,7 @@ function ProductDetails({ product: staleProduct }: Props) {
 
   return (
     <div>
-      <Breadcrumb breadcrumbList={breadcrumbs.itemListElement} divider="" />
+      <Breadcrumb breadcrumbList={breadcrumbs.itemListElement} />
       <h2>{variantName}</h2>
       <Image
         src={productImages[0].url}

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -63,7 +63,7 @@ function ProductDetails({ product: staleProduct }: Props) {
 
   return (
     <div>
-      <Breadcrumb breadcrumbList={breadcrumbs.itemListElement} />
+      <Breadcrumb breadcrumbList={breadcrumbs.itemListElement} divider="" />
       <h2>{variantName}</h2>
       <Image
         src={productImages[0].url}

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -25,7 +25,7 @@ function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
   return (
     <UIBreadcrumb divider="">
       <Link aria-label="home" href="/">
-        <HouseIcon size={18} />
+        <HouseIcon size={18} weight="bold" />
       </Link>
 
       {breadcrumbList.map(({ item, name }, index) => {

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -4,6 +4,8 @@ import Link from 'src/components/ui/Link'
 import type { BreadcrumbProps as UIBreadcrumbProps } from '@faststore/ui'
 import { House as HouseIcon } from 'phosphor-react'
 
+import './breadcrumb.scss'
+
 type ItemElement = {
   item: string
   name: string

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -15,7 +15,7 @@ export interface BreadcrumbProps extends UIBreadcrumbProps {
   breadcrumbList: ItemElement[]
 }
 
-function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
+function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
   const buildUrl = (url: string) => {
     const parsedUrl = url.split('/')
 
@@ -23,9 +23,9 @@ function Breadcrumb({ breadcrumbList, divider }: BreadcrumbProps) {
   }
 
   return (
-    <UIBreadcrumb divider={divider}>
+    <UIBreadcrumb divider="">
       <Link aria-label="home" href="/">
-        <HouseIcon />
+        <HouseIcon size={18} />
       </Link>
 
       {breadcrumbList.map(({ item, name }, index) => {

--- a/src/components/ui/Breadcrumb/breadcrumb.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.scss
@@ -5,9 +5,14 @@
   [data-store-breadcrumb-list] {
     display: flex;
     align-items: center;
+    overflow-x: hidden;
 
     [data-store-breadcrumb-item] {
-      display: flex;
+      display: block;
+      width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
 
       svg {
         color: var(--color-text);
@@ -21,7 +26,12 @@
     }
 
     [data-store-link] {
+      display: flex;
       padding: 0;
+
+      &:visited {
+        color: var(--color-link);
+      }
     }
 
     [data-store-breadcrumb-item="current"] {

--- a/src/components/ui/Breadcrumb/breadcrumb.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.scss
@@ -1,19 +1,31 @@
 [data-store-breadcrumb] {
   width: 100%;
-  padding: 12px 16px;
+  padding: var(--space-2) var(--space-3);
 
   [data-store-breadcrumb-list] {
     display: flex;
     align-items: center;
 
+    [data-store-breadcrumb-item] {
+      display: flex;
+
+      svg {
+        color: var(--color-text);
+      }
+    }
+
     [data-store-breadcrumb-divider] {
-      height: 14px;
-      margin: 0 10px 0 8px;
-      border-left: 1px solid #c7ccd1;
+      height: var(--space-3);
+      margin: 0 var(--space-2) 0 var(--space-1);
+      border-left: var(--border-width-0) solid var(--color-border-display);
     }
 
     [data-store-link] {
       padding: 0;
+    }
+
+    [data-store-breadcrumb-item="current"] {
+      color: var(--color-text-disabled);
     }
   }
 }

--- a/src/components/ui/Breadcrumb/breadcrumb.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.scss
@@ -1,0 +1,19 @@
+[data-store-breadcrumb] {
+  width: 100%;
+  padding: 12px 16px;
+
+  [data-store-breadcrumb-list] {
+    display: flex;
+    align-items: center;
+
+    [data-store-breadcrumb-divider] {
+      height: 14px;
+      margin: 0 10px 0 8px;
+      border-left: 1px solid #c7ccd1;
+    }
+
+    [data-store-link] {
+      padding: 0;
+    }
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR styles the Breadcrumb component

## How it works? 
Add a stylesheet for Breadcrumb and implement a style like the [Figma Prototype](https://www.figma.com/file/wS0Kek1aSzIRl20jdtnSsL/Alpha-Version?node-id=0%3A1)

![Screen Shot 2021-12-30 at 16 18 41](https://user-images.githubusercontent.com/51174217/147781888-b013a76b-f126-4971-b531-3a2a2fd1ea0e.png)


