### PR TITLE
Chore: tweaks input search

### DIFF
--- a/src/components/common/SearchInput/search-input.scss
+++ b/src/components/common/SearchInput/search-input.scss
@@ -11,7 +11,7 @@
 
 [data-store-search-input] [data-store-input] {
   width: 100%;
-  padding: var(--space-1) var(--space-2);
+  padding: var(--space-1) var(--space-7) var(--space-1) var(--space-2);
   border: var(--border-width-0) solid var(--color-border-input);
   border-radius: var(--border-radius-default);
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR tweaks the input search right padding that was overlapping the icon. 

|Before|After|
|-|-|
|<img width="480" alt="Screen Shot 2022-01-03 at 14 46 26" src="https://user-images.githubusercontent.com/11325562/147962441-66c300ea-b7f9-4c55-b35a-80e6f0ab939c.png">|<img width="483" alt="Screen Shot 2022-01-03 at 14 45 51" src="https://user-images.githubusercontent.com/11325562/147962600-39e1d658-0327-4a7e-b3db-b969d870c5cf.png">|

