### PR TITLE
feat: Adds SROnly component

### DIFF
--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -101,7 +101,7 @@ function ProductCard({
               data-value={listPrice}
               variant="listing"
               classes="text-body-small"
-              SRText="Original price:"
+              sr-text="Original price:"
             />
             <Price
               value={spotPrice}

--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -101,6 +101,7 @@ function ProductCard({
               data-value={listPrice}
               variant="listing"
               classes="text-body-small"
+              SRText="Original price:"
             />
             <Price
               value={spotPrice}
@@ -109,6 +110,7 @@ function ProductCard({
               data-value={spotPrice}
               variant="spot"
               classes="text-body"
+              SRText="Sale Price:"
             />
           </div>
         </div>

--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -101,7 +101,7 @@ function ProductCard({
               data-value={listPrice}
               variant="listing"
               classes="text-body-small"
-              sr-text="Original price:"
+              SRText="Original price:"
             />
             <Price
               value={spotPrice}
@@ -110,7 +110,7 @@ function ProductCard({
               data-value={spotPrice}
               variant="spot"
               classes="text-body"
-              sr-text="Sale Price:"
+              SRText="Sale Price:"
             />
           </div>
         </div>

--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -110,7 +110,7 @@ function ProductCard({
               data-value={spotPrice}
               variant="spot"
               classes="text-body"
-              SRText="Sale Price:"
+              sr-text="Sale Price:"
             />
           </div>
         </div>

--- a/src/components/ui/Price/Price.tsx
+++ b/src/components/ui/Price/Price.tsx
@@ -10,7 +10,7 @@ type Props = PriceProps & {
   /**
    * Text for the screen readers only
    */
-  'sr-text': string
+  SRText: string
   /**
    * Other classes that might be applied
    */

--- a/src/components/ui/Price/Price.tsx
+++ b/src/components/ui/Price/Price.tsx
@@ -2,15 +2,28 @@ import React from 'react'
 import { Price as UIPrice } from '@faststore/ui'
 import type { PriceProps } from '@faststore/ui'
 
+import SROnly from '../SROnly'
+
 import './price.scss'
 
 type Props = PriceProps & {
-  // other classes
+  /**
+   * Text for the screen readers only
+   */
+  SRText: string
+  /**
+   * Other classes that might be applied
+   */
   classes?: string
 }
 
-function Price({ classes, ...props }: Props) {
-  return <UIPrice className={`price ${classes}`} {...props} />
+function Price({ classes, SRText, ...props }: Props) {
+  return (
+    <>
+      <SROnly text={SRText} />
+      <UIPrice className={`price ${classes}`} {...props} />
+    </>
+  )
 }
 
 export default Price

--- a/src/components/ui/Price/Price.tsx
+++ b/src/components/ui/Price/Price.tsx
@@ -10,7 +10,7 @@ type Props = PriceProps & {
   /**
    * Text for the screen readers only
    */
-  SRText: string
+  'sr-text': string
   /**
    * Other classes that might be applied
    */

--- a/src/components/ui/SROnly/SROnly.tsx
+++ b/src/components/ui/SROnly/SROnly.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import './sr-only.scss'
+
+interface Props {
+  text: string
+}
+
+function SROnly({ text }: Props) {
+  return <span data-store-sr-only>{text}</span>
+}
+
+export default SROnly

--- a/src/components/ui/SROnly/index.tsx
+++ b/src/components/ui/SROnly/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SROnly'

--- a/src/components/ui/SROnly/sr-only.scss
+++ b/src/components/ui/SROnly/sr-only.scss
@@ -1,0 +1,9 @@
+[data-store-sr-only]:not(:focus):not(:active) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}


### PR DESCRIPTION
## What's the purpose of this pull request?
- "sr-only" means "screen reader only"
- Introducing this technique for hiding content when other approaches are unavailable. We should use this component to give extra context that could be visibly hidden in the interface.
- Aims to deliver better experience for screen readers users.

## How it works? 
- Visually, nothing changes.

https://user-images.githubusercontent.com/3356699/148112592-4223b85b-2051-419d-b3b0-e3e000d43e47.mov




## References
- https://webaim.org/techniques/css/invisiblecontent/
