### PR TITLE
Chore: Renames ProductSummary to ProductCard

### DIFF
--- a/src/components/product/ProductCard/ProductCard.tsx
+++ b/src/components/product/ProductCard/ProductCard.tsx
@@ -14,7 +14,7 @@ interface Props {
   className?: string
 }
 
-function ProductSummary({ product, index, className }: Props) {
+function ProductCard({ product, index, className }: Props) {
   const {
     id,
     sku,
@@ -136,4 +136,4 @@ export const fragment = graphql`
   }
 `
 
-export default ProductSummary
+export default ProductCard

--- a/src/components/product/ProductCard/index.tsx
+++ b/src/components/product/ProductCard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ProductCard'

--- a/src/components/product/ProductGrid/ProductGrid.tsx
+++ b/src/components/product/ProductGrid/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
 
-import ProductSummary from '../ProductSummary'
+import ProductCard from '../ProductCard'
 
 interface Props {
   products: ProductSummary_ProductFragment[]
@@ -13,7 +13,7 @@ function ProductGrid({ products, page, pageSize }: Props) {
   return (
     <div className="grid grid-cols-2 gap-2 mb-2 sm:grid-cols-4 sm:gap-7 sm:mb-7">
       {products.map((product, idx) => (
-        <ProductSummary
+        <ProductCard
           key={`${product.id}`}
           product={product}
           index={pageSize * page + idx + 1}

--- a/src/components/product/ProductSummary/index.tsx
+++ b/src/components/product/ProductSummary/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './ProductSummary'


### PR DESCRIPTION
## What's the purpose of this pull request?

- Renames `ProductSummary` component to `ProductCard`
- In order to adopt a common language for the team

## References
- https://www.notion.so/vtexhandbook/FastStore-Components-5327450cefcc43a59b723ddc6869dd6f