### PR TITLE
fix: hero image quality

### DIFF
--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -46,12 +46,10 @@ const Hero = ({
         <Image
           baseUrl={imageSrc}
           alt={imageAlt}
-          sourceWidth={720}
           aspectRatio={2}
-          width={800}
-          breakpoints={[480, 540, 720]}
-          layout="constrained"
+          layout="fullWidth"
           backgroundColor="#f0f0f0"
+          loading="eager"
           options={{
             fitIn: true,
           }}


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR aims to enhance the quality of the image being rendered inside the `Hero` component. 

## How it works? 
It **removes** optional parameters passed to `GatsbyImage` and let it choose them automatically:
- `sourceWidth`
  - **Why?** - docs are not really clear about this (I've found no concrete explanation about what this really does) but the comment on the file `hooks.d.ts` says: "_If available, pass the source image width and height_". Since this was optional and I wanted to make this as flexible as possible (since we do not know the size of the image that will be used for the Hero beforehand) I decided to remove this parameter, instead leaving an hardcoded arbitrary value (as it was before).
- `width`
  - **Why?** - `width` is not used in `fullWidth` layout. Docs: "_For fixed and constrained images, you can also optionally pass either a width or height, and it will use that to calculate the other dimension._" and also "_For fullWidth images you don’t specify width or height, as it resizes to fit the screen width. Passing aspectRatio will crop the image if needed, and the height will scale according to the width of the screen._"
- `breakpoints`
  - **Why?** - From the docs about `breakpoints` - "_Output widths to generate for full width images. Default is to generate widths for common device resolutions. It will never generate an image larger than the source image. The browser will automatically choose the most appropriate._". The default seemed pretty reasonable to me, so I decided to remove that as well instead of hardcoding arbitrary breakpoints.

It also **changes and adds** parameters to enhance the image quality/loading:
- Changed `layout` from `constrained` to `fullWidth`
  - **Why?** - This is probably the most important parameter, since it is designed to work especially well with the Hero component. Docs: "_Use this for images that are always displayed at the full width of the screen, such as banners or hero images. Like the constrained layout, this resizes to fit the container. However it is not restricted to a maximum size, so will grow to fill the container however large it is, maintaining its aspect ratio. It generates several smaller image sizes for different screen breakpoints, so that the browser only needs to load one large enough to fit the screen. You can pass a breakpoints prop if you want to specify the sizes to use, though in most cases you can allow it to use the default._"

- Added `loading` parameter with the `eager` value.
  - **Why?** - Docs about the `loading` parameter: "_Loading behavior for the image. You should set this to "eager" for above-the-fold images to ensure they start loading before React hydration._" 

## How to test it?
Open the homepage, the image should be in a higher quality and adapt itself to different screen sizes. It also should show as 2x pixel density in retina devices.
Also verify that all tests still pass with `yarn test`

## References
[gatsby-image-plugin docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/#layout) - especially the "image > layout" section
Thanks to @hellofanny for all the help.