### PR TITLE
Fix: Adjust Data Layer has event

### DIFF
--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -15,11 +15,15 @@ beforeEach(() => {
 })
 
 const dataLayerHasEvent = (eventName) => {
-  return cy.window().then((window) => {
-    const allEvents = window.dataLayer.map((evt) => evt.event)
+  cy.waitUntil(
+    () =>
+      cy.window({ log: false }).then((window) => {
+        const allEvents = window.dataLayer.map((evt) => evt.event)
 
-    expect(allEvents).to.include(eventName)
-  })
+        return allEvents.includes(eventName)
+      }),
+    { errorMsg: `Event ${eventName} not found` }
+  ).then((assert) => expect(assert).to.be.true)
 }
 
 const eventDataHasCurrencyProperty = () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,8 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import 'cypress-wait-until'
+
 Cypress.Commands.add('getById', (selector, ...args) => {
   return cy.get(`[data-testid=${selector}]`, ...args)
 })

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "autoprefixer": "^10.4.0",
     "axe-core": "^4.3.3",
     "cypress-axe": "^0.13.0",
+    "cypress-wait-until": "^1.7.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.22.0",
     "eslint-config-vtex-react": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5597,6 +5597,11 @@ cypress-axe@^0.13.0:
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.13.0.tgz#3234e1a79a27701f2451fcf2f333eb74204c7966"
   integrity sha512-fCIy7RiDCm7t30U3C99gGwQrUO307EYE1QqXNaf9ToK4DVqW8y5on+0a/kUHMrHdlls2rENF6TN9ZPpPpwLrnw==
 
+cypress-wait-until@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
+  integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
+
 cypress@*:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.1.1.tgz#26720ca5a22077cd85f49745616b7a08152a298f"


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>


## What's the purpose of this pull request?
Fix analytics events with intermittent errosr. Adding [cypress-wait-until](https://www.npmjs.com/package/cypress-wait-until) dependence and fixing dataLayerHasEvent
