### PR TITLE
Feat: Sizing improvements (Hero + Incentives)

### DIFF
--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -37,9 +37,15 @@ const Hero = ({
       <HeroContent aria-labelledby="hero-heading">
         <div className="hero-content-wrapper / grid-content">
           <div className="hero-content-info">
-            <h1 id="hero-heading" className="title-hero">
+            <h1
+              id="hero-heading"
+              className={
+                variant === 'default' ? 'title-hero' : 'title-hero-small'
+              }
+            >
               {title}
             </h1>
+
             <p className="text-body-big">{subtitle}</p>
             {!!link && (
               <HeroLink>

--- a/src/components/sections/Incentives/incentives.scss
+++ b/src/components/sections/Incentives/incentives.scss
@@ -1,14 +1,15 @@
 @import "../../../styles/scaffold";
 
 .incentives {
+  display: flex;
+  justify-content: center;
+
   [data-store-list] {
     display: flex;
+    width: fit-content;
     overflow-x: auto;
 
     @include media("<notebook") {
-      padding-top: var(--space-2);
-      padding-bottom: var(--space-2);
-
       li {
         &:not(:first-child) {
           [data-store-incentive] {
@@ -83,6 +84,8 @@
   }
 
   &.incentives--colored {
+    padding-top: var(--space-4);
+    padding-bottom: var(--space-4);
     background-color: var(--bg-secondary-light);
   }
 }

--- a/src/components/ui/Hero/hero.scss
+++ b/src/components/ui/Hero/hero.scss
@@ -27,14 +27,19 @@
       gap: var(--space-3);
       justify-content: space-between;
 
-      @include media(">=tablet") {
-        gap: var(--space-1);
-        justify-content: flex-start;
+      @include media(">=tablet", "<notebook") {
+        justify-content: space-between;
+        width: 50%;
+        margin-left: 0;
       }
+
+      @include media(">=tablet") { gap: var(--space-1); }
+
+      @include media(">=notebook") { justify-content: flex-start; }
     }
 
     .hero-content-info {
-      @include media(">=tablet") { width: 42%; }
+      @include media(">=notebook") { width: 42%; }
     }
 
     p {

--- a/src/components/ui/Hero/hero.scss
+++ b/src/components/ui/Hero/hero.scss
@@ -34,9 +34,7 @@
     }
 
     .hero-content-info {
-      @include media(">=tablet") {
-        max-width: 42%;
-      }
+      @include media(">=tablet") { width: 42%; }
     }
 
     p {
@@ -72,8 +70,7 @@
   [data-hero-image] {
     [data-gatsby-image-wrapper] {
       width: 100%;
-
-      @include media(">=tablet") { height: 100%; }
+      height: 100%;
     }
 
     @include media(">=tablet") {
@@ -85,10 +82,10 @@
   }
 
   &[data-hero-variant="default"] {
-    min-height: 18.75rem;
+    @include media(">=tablet") { min-height: 18.75rem; }
 
     [data-hero-content] {
-      @include media(">=tablet") { padding: var(--space-13) 0; }
+      @include media(">=tablet") { padding: var(--space-9) 0; }
     }
 
     .hero-content-info {
@@ -103,14 +100,14 @@
     }
 
     [data-hero-image] {
-      [data-gatsby-image-wrapper] { min-height: 18.75rem; }
+      @include media("<tablet") { height: 15rem; }
 
       @include media(">=tablet") { width: 53%; }
     }
   }
 
   &[data-hero-variant="small"] {
-    min-height: 14.18rem;
+    @include media(">=tablet") { min-height: 14.18rem; }
 
     [data-hero-content] {
       padding: var(--space-4) 0 var(--space-3);
@@ -121,7 +118,7 @@
     }
 
     [data-hero-image] {
-      [data-gatsby-image-wrapper] { min-height: 14.18rem; }
+      @include media("<tablet") { height: 11.25rem; }
 
       @include media(">=tablet") { width: 50%; }
     }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -74,6 +74,7 @@
 
   // Paddings
   --page-padding-phone: var(--space-3);
+  --page-padding-tablet: var(--space-4);
   --page-padding-notebook: var(--space-5);
 
   // Target Size

--- a/src/styles/grid.scss
+++ b/src/styles/grid.scss
@@ -31,6 +31,11 @@
   padding-right: var(--page-padding-phone);
   padding-left: var(--page-padding-phone);
 
+  @include media(">=tablet") {
+    padding-right: var(--page-padding-tablet);
+    padding-left: var(--page-padding-tablet);
+  }
+
   @include media(">=notebook") {
     padding-right: var(--page-padding-notebook);
     padding-left: var(--page-padding-notebook);

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -36,6 +36,14 @@ h1, h2, h3, h4, h5, h6, p, ul {
   @include media(">=tablet") { font-size: var(--text-size-7); }
 }
 
+.title-hero-small {
+  font-weight: var(--text-weight-black);
+  font-size: var(--text-size-5);
+  line-height: 1.1;
+
+  @include media(">=tablet") { font-size: var(--text-size-6); }
+}
+
 .title-display-big {
   font-weight: var(--text-weight-bold);
   font-size: var(--text-size-3);


### PR DESCRIPTION
## What's the purpose of this pull request?
Improve Hero and Incentives heights to adapt better on all devices.

## How it works? 
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/11613011/149535352-e6137d2e-61de-413d-8b4d-8b55770b6e2c.png)|![image](https://user-images.githubusercontent.com/11613011/149535394-5209a33f-d7ac-4ee5-a19b-334ab6208dbb.png)|
|![image](https://user-images.githubusercontent.com/11613011/149535499-6f56966e-ad89-46f0-91fd-1472e1287831.png)|![image](https://user-images.githubusercontent.com/11613011/149535574-221f1684-29e3-40b0-a3d4-03fffc9a3c6e.png)|
|![image](https://user-images.githubusercontent.com/11613011/149542387-f3351c61-c4c0-4349-a219-f65743d96553.png)|![image](https://user-images.githubusercontent.com/11613011/149542422-86252e9c-300f-4cef-9678-d41f411dac55.png)|
|![image](https://user-images.githubusercontent.com/11613011/149542614-3022fdc9-1261-4a9d-a030-47aba657177d.png)|![image](https://user-images.githubusercontent.com/11613011/149542660-dbe7c241-440f-456e-9279-c3694cf707b8.png)|
|![image](https://user-images.githubusercontent.com/11613011/149542756-b4b77a7b-bd06-46c9-99c1-45195224fe6b.png)|![image](https://user-images.githubusercontent.com/11613011/149542786-f99c1776-a64e-4c99-9877-ce1ffd4f4023.png)|


## How to test it?
Se the preview of the [Homepage Hero & Colored Incentives](https://sfj-b34fd69--base.preview.vtex.app/) and [PLP hero](https://sfj-b34fd69--base.preview.vtex.app/office/).
