### PR TITLE
Fix Lighthouse check due to an unused pre-connection

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -42,12 +42,6 @@ export const onRenderBody = ({ setHeadComponents }) => {
         enablePartytown
       />,
       <Partytown key="party" />,
-      <link
-        key="preconnect"
-        rel="preconnect"
-        crossOrigin
-        href="https://googletagmanager.com"
-      />,
     ])
   } else if (process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line


### PR DESCRIPTION
## What's the purpose of this pull request?
Last PR merged to `master` (#228) was passing CI, but [failed](https://github.com/vtex-sites/base.store/runs/4817817480) once merged.

This PR removes the `preconnect` because there was the following warning:

![CleanShot 2022-01-14 at 12 07 22](https://user-images.githubusercontent.com/381395/149537754-ea085f39-32a9-4034-82d3-31f307e1a00a.png)