### PR TITLE
Add markup for the Newsletter component

### DIFF
--- a/src/components/sections/Newsletter/Newsletter.tsx
+++ b/src/components/sections/Newsletter/Newsletter.tsx
@@ -1,0 +1,82 @@
+import type { ComponentPropsWithRef, FormEvent, ReactNode } from 'react'
+import React, { forwardRef, useRef } from 'react'
+import { Form, Label, Input, Button } from '@faststore/ui'
+
+export interface NewsletterProps
+  extends Omit<ComponentPropsWithRef<'form'>, 'onSubmit'> {
+  /**
+   * Heading for the section.
+   */
+  heading: ReactNode
+  /**
+   * Description about the newsletter.
+   */
+  description?: ReactNode
+  /**
+   * Callback function when submitted.
+   */
+  onSubmit: (value: string) => void
+}
+
+const Newsletter = forwardRef<HTMLFormElement, NewsletterProps>(
+  function Newsletter({ heading, description, onSubmit, ...otherProps }, ref) {
+    const emailInputRef = useRef<HTMLInputElement>(null)
+
+    const handleSubmit = (event: FormEvent) => {
+      event.preventDefault()
+
+      if (emailInputRef.current?.value !== '') {
+        onSubmit(emailInputRef.current!.value)
+      }
+    }
+
+    return (
+      <Form
+        data-store-newsletter
+        ref={ref}
+        onSubmit={handleSubmit}
+        {...otherProps}
+      >
+        <div data-newsletter-content>
+          {heading}
+          {Boolean(description) && description}
+        </div>
+
+        <div data-newsletter-controls>
+          <Label htmlFor="newsletter-email">Your email</Label>
+          <Input
+            id="newsletter-email"
+            type="email"
+            name="newsletter-email"
+            ref={emailInputRef}
+          />
+          <Button type="submit">Subscribe</Button>
+        </div>
+      </Form>
+    )
+  }
+)
+
+export default Newsletter
+
+/*
+Example of use:
+<Newsletter
+  heading={
+    <h3>
+      <EnvelopIcon size={16}
+      Get news and special offers
+    </h3>
+  }
+  description={
+    <p>
+      Receive our news and promotions in advance. Enjoy and get 10% off
+      your first purchase. For more information{' '}
+      <Link to="/">click here</Link>.
+    </p>
+  }
+  onSubmit={(email) => {
+    alert(`Subscribing ${email} to the newsletter.`)
+  }}
+/>
+ */

--- a/src/components/sections/Newsletter/index.tsx
+++ b/src/components/sections/Newsletter/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './Newsletter'
+export type { NewsletterProps } from './Newsletter'


### PR DESCRIPTION
## What's the purpose of this pull request?

Implement a basic markup of an unstyled version of the Newsletter component described in [this Figma file](https://www.figma.com/file/zHMOtOPduiM0hNNcg21iR1/Handoff-PDP-v0.1?node-id=36%3A41903).

![image](https://user-images.githubusercontent.com/381395/149788052-cdf512fb-e9c7-4182-b368-9dc9afab7a4e.png)

## How it works? 

```jsx
<Newsletter
  heading={
    <h3>
      <EnvelopIcon size={16}
      Get news and special offers
    </h3>
  }
  description={
    <p>
      Receive our news and promotions in advance. Enjoy and get 10% off
      your first purchase. For more information{' '}
      <Link to="/">click here</Link>.
    </p>
  }
  onSubmit={(email) => {
    alert(`Subscribing ${email} to the newsletter.`)
  }}
/>
```

## How to test it?

There's no way to test it right now because it isn't being used anywhere.

## References

- [Jira FSSS-37 Newsletter component](https://vtex-dev.atlassian.net/browse/FSSS-37)
- [Design on Figma](https://www.figma.com/file/zHMOtOPduiM0hNNcg21iR1/Handoff-PDP-v0.1?node-id=36%3A41903)