### PR TITLE
Fix: Attempt to fix PLP Lighthouse CLS issue

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -47,7 +47,7 @@ function Layout({ children }: PropsWithChildren<unknown>) {
 
       <Navbar />
 
-      <main>{children}</main>
+      <main className="temp-cls-fix">{children}</main>
 
       <Footer />
       {displayMinicart && (

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -111,3 +111,13 @@
   --breakpoint-notebook: 1280px;
   --breakpoint-desktop: 1440px;
 }
+
+main.temp-cls-fix {
+  // NOTE: Temporary fix to make sure the footer stays below the fold so
+  // there's not much CLS after the main content is loaded.
+  // Remove when skeletons are used!
+  --alert-height: 48px;
+  --navbar-height: 117px;
+
+  min-height: calc(100vh - var(--alert-height) - var(--navbar-height));
+}

--- a/src/styles/pages/index.scss
+++ b/src/styles/pages/index.scss
@@ -3,15 +3,6 @@
 main {
   display: flex;
   flex-wrap: wrap;
-
-  &.temp-cls-fix {
-    // NOTE: Make sure the footer stays below the fold so there's no CLS after
-    // the main content is loaded. Remove when skeletons are used.
-    --alert-height: 48px;
-    --navbar-height: 117px;
-
-    min-height: calc(100vh - var(--alert-height) - var(--navbar-height));
-  }
 }
 
 .page__section {

--- a/src/styles/pages/index.scss
+++ b/src/styles/pages/index.scss
@@ -3,6 +3,15 @@
 main {
   display: flex;
   flex-wrap: wrap;
+
+  &.temp-cls-fix {
+    // NOTE: Make sure the footer stays below the fold so there's no CLS after
+    // the main content is loaded. Remove when skeletons are used.
+    --alert-height: 48px;
+    --navbar-height: 117px;
+
+    min-height: calc(100vh - var(--alert-height) - var(--navbar-height));
+  }
 }
 
 .page__section {


### PR DESCRIPTION
## What's the purpose of this pull request?

Another attempt to fix PLP's Cumulate Layout Shift plaguing `main-style` and its other branches.

## How does it work? 

On the PLP page load, the footer starts occupying a big part of the viewport and it has some internal layout shifts in the incentives list area, as well as the transformation of the footer links into the accordion.

Incentives|Accordion
-|-
![incentives](https://user-images.githubusercontent.com/381395/149962359-04cd3fc7-8435-41f7-b5e2-47c983966e5e.gif)|![accordion](https://user-images.githubusercontent.com/381395/149962377-86ea9aeb-8a31-4c28-8cdc-13e8c0eb365f.gif)

This temporary fix increases the minimum height of the main element so it pushes the footer the minimum amount to be below the fold. That is possible because the height of the alert and navbar don't change frequently. It's believed that when https://github.com/vtex-sites/base.store/pull/240 lands, we won't need this fix and can remove it. Or when we implement page skeletons in the future.

## How to test it?

The Lighthouse CI check passes.

Before|After
-|-
![Before](https://user-images.githubusercontent.com/381395/149962473-7376bc46-1933-41a0-833e-903536dd41dc.gif)|![After](https://user-images.githubusercontent.com/381395/149962492-f4bd0c96-ecaf-44fe-8ce8-dd84a232a25b.gif)

## References

- Another attempt to fix this is at https://github.com/vtex-sites/base.store/pull/247 but the CLS still failed in one of the commits.