### PR TITLE
Remove duplicate product name on PDP

### DIFF
--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -204,7 +204,7 @@ function ProductDetails({ product: staleProduct }: Props) {
 
         <section className="product-details__content">
           <article className="product-details__description">
-            <h3 className="title-subsection">Description</h3>
+            <h2 className="title-subsection">Description</h2>
             <p className="text-body">{description}</p>
           </article>
         </section>

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -115,7 +115,7 @@ function ProductDetails({ product: staleProduct }: Props) {
       <section className="product-details__body">
         <header className="product-details__title">
           <ProductTitle
-            title={<h2 className="title-product">{name}</h2>}
+            title={<h1 className="title-product">{name}</h1>}
             label={<DiscountBadge listPrice={listPrice} spotPrice={lowPrice} />}
             refNumber={productId}
           />

--- a/src/pages/{StoreProduct.slug}/p.tsx
+++ b/src/pages/{StoreProduct.slug}/p.tsx
@@ -96,7 +96,6 @@ function Page(props: Props) {
         Sections: Components imported from '../components/sections' only.
         Do not import or render components from any other folder in here.
       */}
-      <h1>{title}</h1>
 
       <ProductDetails product={product} />
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Remove a visual bug caused by the product name appearing above the breadcrumb on the PDP.

## How it works? 

It was an `h1` that was moved inside the `ProductTitle`.

Before|After
-|-
![Screen Shot 2022-01-18 at 10 54 36](https://user-images.githubusercontent.com/381395/149951870-1c4c6c30-b915-461e-a68b-b754680fa253.png)|![Screen Shot 2022-01-18 at 11 02 46](https://user-images.githubusercontent.com/381395/149951896-e0c835bc-4849-4527-b8bb-f80823c6fc14.png)

## How to test it?
Visit any PDP on the deploy preview (e.g. https://preview-251--base.preview.vtex.app/sleek-steel-table-58621790/p/).