### PR TITLE
chore: change store url to vtexfaststore.com

### DIFF
--- a/store.config.js
+++ b/store.config.js
@@ -12,8 +12,8 @@ module.exports = {
   channel: '1',
 
   // Production URLs
-  storeUrl: 'https://www.vtex-base1.tk',
-  checkoutUrl: 'https://chk.vtex-base1.tk/checkout',
+  storeUrl: 'https://vtexfaststore.com',
+  checkoutUrl: 'https://secure.vtexfaststore.com/checkout',
 
   // Lighthouse CI
   lighthouse: {


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR changes the store url to vtexfaststore.com, our official website for base.store.