### PR TITLE
[FSSS-151] Feat: Styles Accordion and Replace

### DIFF
--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -84,6 +84,29 @@ const links = [
   },
 ]
 
+type LinkItem = {
+  href: string
+  name: string
+}
+
+interface LinksListProps {
+  items: LinkItem[]
+}
+
+function LinksList({ items }: LinksListProps) {
+  return (
+    <UIList>
+      {items.map((item) => (
+        <li key={item.name}>
+          <Link variant="footer" href={item.href}>
+            {item.name}
+          </Link>
+        </li>
+      ))}
+    </UIList>
+  )
+}
+
 function FooterLinks() {
   const [indicesExpanded, setIndicesExpanded] = useState<Set<number>>(
     new Set([])
@@ -121,15 +144,7 @@ function FooterLinks() {
               key={section.title}
               buttonLabel={section.title}
             >
-              <UIList>
-                {section.items.map((item) => (
-                  <li key={item.name}>
-                    <Link variant="footer" href={item.href}>
-                      {item.name}
-                    </Link>
-                  </li>
-                ))}
-              </UIList>
+              <LinksList items={section.items} />
             </AccordionItem>
           ))}
         </Accordion>
@@ -138,15 +153,7 @@ function FooterLinks() {
           {links.map((section) => (
             <nav key={section.title}>
               <p className="title-sub-subsection">{section.title}</p>
-              <UIList>
-                {section.items.map((item) => (
-                  <li key={item.name}>
-                    <Link variant="footer" href={item.href}>
-                      {item.name}
-                    </Link>
-                  </li>
-                ))}
-              </UIList>
+              <LinksList items={section.items} />
             </nav>
           ))}
         </div>

--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -1,18 +1,8 @@
 import React, { useState, useEffect } from 'react'
-import {
-  Icon as UIIcon,
-  List as UIList,
-  Accordion as UIAccordion,
-  AccordionItem as UIAccordionItem,
-  AccordionButton as UIAccordionButton,
-  AccordionPanel as UIAccordionPanel,
-} from '@faststore/ui'
-import {
-  PlusCircle as PlusCircleIcon,
-  MinusCircle as MinusCircleIcon,
-} from 'phosphor-react'
+import { List as UIList } from '@faststore/ui'
 
 import Link from '../../ui/Link'
+import Accordion, { AccordionItem } from '../../ui/Accordion'
 import useWindowDimensions from './useWindowDimensions'
 
 const links = [
@@ -124,35 +114,25 @@ function FooterLinks() {
   return (
     <section className="footer__links">
       {isMobile ? (
-        <UIAccordion indices={indicesExpanded} onChange={onChange}>
+        <Accordion expandedIndices={indicesExpanded} onChange={onChange}>
           {links.map((section, index) => (
-            <UIAccordionItem key={section.title}>
-              <UIAccordionButton className="title-subsection">
-                {section.title}
-                <UIIcon
-                  component={
-                    indicesExpanded.has(index) ? (
-                      <MinusCircleIcon size={24} />
-                    ) : (
-                      <PlusCircleIcon size={24} />
-                    )
-                  }
-                />
-              </UIAccordionButton>
-              <UIAccordionPanel>
-                <UIList>
-                  {section.items.map((item) => (
-                    <li key={item.name}>
-                      <Link variant="footer" href={item.href}>
-                        {item.name}
-                      </Link>
-                    </li>
-                  ))}
-                </UIList>
-              </UIAccordionPanel>
-            </UIAccordionItem>
+            <AccordionItem
+              isExpanded={indicesExpanded.has(index)}
+              key={section.title}
+              buttonLabel={section.title}
+            >
+              <UIList>
+                {section.items.map((item) => (
+                  <li key={item.name}>
+                    <Link variant="footer" href={item.href}>
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </UIList>
+            </AccordionItem>
           ))}
-        </UIAccordion>
+        </Accordion>
       ) : (
         <div className="footer__links-columns">
           {links.map((section) => (

--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -140,8 +140,8 @@ function FooterLinks() {
         <Accordion expandedIndices={indicesExpanded} onChange={onChange}>
           {links.map((section, index) => (
             <AccordionItem
-              isExpanded={indicesExpanded.has(index)}
               key={section.title}
+              isExpanded={indicesExpanded.has(index)}
               buttonLabel={section.title}
             >
               <LinksList items={section.items} />

--- a/src/components/common/Footer/footer.scss
+++ b/src/components/common/Footer/footer.scss
@@ -145,35 +145,11 @@
 }
 
 .footer__links {
-  [data-store-accordion] {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    [data-store-list] { margin-bottom: var(--space-2); }
-  }
-
-  [data-accordion-item] {
-    border-bottom: 1px solid var(--color-border-display);
-  }
+  [data-store-list] { margin-bottom: var(--space-2); }
 
   [data-store-link] {
     display: inline-block;
     padding-left: 0;
-  }
-
-  [data-accordion-item] [data-store-button] {
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: var(--space-3) 0;
-    color: var(--color-text);
-    background-color: transparent;
-    border: 0;
-  }
-
-  [data-accordion-item] [data-store-icon] {
-    display: flex;
   }
 
   @include media(">=notebook") { grid-column: span 8; }

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -47,7 +47,7 @@ function Filter({
   const { width: screenWidth } = useWindowDimensions()
   const { toggleFacet, toggleFacets, state: searchState } = useSearch()
 
-  const [expandedIndices, setExpandedIndices] = useState<Set<number>>(
+  const [indicesExpanded, setIndicesExpanded] = useState<Set<number>>(
     new Set([])
   )
 
@@ -65,14 +65,14 @@ function Filter({
   }, [screenWidth])
 
   const onAccordionChange = (index: number) => {
-    if (expandedIndices.has(index)) {
-      expandedIndices.delete(index)
-      setExpandedIndices(new Set(expandedIndices))
+    if (indicesExpanded.has(index)) {
+      indicesExpanded.delete(index)
+      setIndicesExpanded(new Set(indicesExpanded))
 
       return
     }
 
-    setExpandedIndices(new Set(expandedIndices.add(index)))
+    setIndicesExpanded(new Set(indicesExpanded.add(index)))
   }
 
   const onFilterChange = (item: IStoreSelectedFacet) => {
@@ -103,7 +103,7 @@ function Filter({
       <div className="filter" data-store-filter data-testid={testId}>
         <h2 className="title-small">Filters</h2>
         <Accordion
-          expandedIndices={expandedIndices}
+          expandedIndices={indicesExpanded}
           onChange={onAccordionChange}
         >
           {facets
@@ -112,7 +112,7 @@ function Filter({
               <AccordionItem
                 key={`${label}-${index}`}
                 testId="filter-accordion"
-                isExpanded={expandedIndices.has(index)}
+                isExpanded={indicesExpanded.has(index)}
                 buttonLabel={label}
               >
                 <UIList>
@@ -172,7 +172,7 @@ function Filter({
           variant="secondary"
           onClick={() => {
             toggleFacets(selectedFilters)
-            setExpandedIndices(new Set([]))
+            setIndicesExpanded(new Set([]))
             setSelectedFilters([])
           }}
         >

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -162,7 +162,7 @@ function Filter({
             aria-label="Close"
             onClick={onDismiss}
           >
-            <XIcon size={18} weight="bold" />
+            <XIcon size={32} />
           </Button>
         </header>
         <Facets />

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -6,24 +6,17 @@ import type {
   FacetedFilter_FacetsFragment,
 } from '@generated/graphql'
 import {
-  Icon as UIIcon,
   List as UIList,
   Modal as UIModal,
-  Accordion as UIAccordion,
-  AccordionItem as UIAccordionItem,
-  AccordionButton as UIAccordionButton,
-  AccordionPanel as UIAccordionPanel,
   Label as UILabel,
 } from '@faststore/ui'
 import useWindowDimensions from 'src/hooks/useWindowDimensions'
 import Button from 'src/components/ui/Button'
 import Checkbox from 'src/components/ui/Checkbox'
 import { Badge } from 'src/components/ui/Badge'
-import {
-  X as XIcon,
-  PlusCircle as PlusCircleIcon,
-  MinusCircle as MinusCircleIcon,
-} from 'phosphor-react'
+import { X as XIcon } from 'phosphor-react'
+
+import Accordion, { AccordionItem } from '../../ui/Accordion'
 
 import './filter.scss'
 
@@ -109,54 +102,48 @@ function Filter({
     return (
       <div className="filter" data-store-filter data-testid={testId}>
         <h2 className="title-small">Filters</h2>
-        <UIAccordion indices={expandedIndices} onChange={onAccordionChange}>
+        <Accordion
+          expandedIndices={expandedIndices}
+          onChange={onAccordionChange}
+        >
           {facets
             .filter((facet) => facet.type === 'BOOLEAN')
             .map(({ label, values, key }, index) => (
-              <UIAccordionItem key={`${label}-${index}`}>
-                <UIAccordionButton data-testid="filter-accordion-button">
-                  {label}
-                  <UIIcon
-                    component={
-                      expandedIndices.has(index) ? (
-                        <MinusCircleIcon size={24} />
-                      ) : (
-                        <PlusCircleIcon size={24} />
-                      )
-                    }
-                  />
-                </UIAccordionButton>
-                <UIAccordionPanel>
-                  <UIList>
-                    {values.map((item) => {
-                      const id = `${label}-${item.label}`
+              <AccordionItem
+                key={`${label}-${index}`}
+                testId="filter-accordion"
+                isExpanded={expandedIndices.has(index)}
+                buttonLabel={label}
+              >
+                <UIList>
+                  {values.map((item) => {
+                    const id = `${label}-${item.label}`
 
-                      return (
-                        <li key={id} className="filter__item">
-                          <Checkbox
-                            id={id}
-                            checked={selectedFilters.some(
-                              (filter) => filter.value === item.value
-                            )}
-                            onChange={() => onCheck({ key, value: item.value })}
-                            data-testid="filter-accordion-panel-checkbox"
-                            data-value={item.value}
-                            data-quantity={item.quantity}
-                          />
-                          <UILabel htmlFor={id} className="title-small">
-                            {item.label}{' '}
-                            <Badge variant="neutral" small>
-                              {item.quantity}
-                            </Badge>
-                          </UILabel>
-                        </li>
-                      )
-                    })}
-                  </UIList>
-                </UIAccordionPanel>
-              </UIAccordionItem>
+                    return (
+                      <li key={id} className="filter__item">
+                        <Checkbox
+                          id={id}
+                          checked={selectedFilters.some(
+                            (filter) => filter.value === item.value
+                          )}
+                          onChange={() => onCheck({ key, value: item.value })}
+                          data-testid="filter-accordion-panel-checkbox"
+                          data-value={item.value}
+                          data-quantity={item.quantity}
+                        />
+                        <UILabel htmlFor={id} className="title-small">
+                          {item.label}{' '}
+                          <Badge variant="neutral" small>
+                            {item.quantity}
+                          </Badge>
+                        </UILabel>
+                      </li>
+                    )
+                  })}
+                </UIList>
+              </AccordionItem>
             ))}
-        </UIAccordion>
+        </Accordion>
       </div>
     )
   }

--- a/src/components/search/Filter/filter.scss
+++ b/src/components/search/Filter/filter.scss
@@ -24,38 +24,14 @@
     }
   }
 
-  [data-accordion-item] {
-    border-bottom: 1px solid var(--color-border-display);
-
-    @include media(">=notebook") {
-      padding: 0 var(--space-4);
-
-      &:last-child {
-        border-bottom: 0;
-      }
-    }
-  }
-
   [data-accordion-item] [data-store-button] {
-    display: inline-flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: var(--space-3) 0;
-    color: var(--color-text);
     font-size: var(--text-size-3);
     line-height: 1.5;
-    background-color: transparent;
-    border: 0;
 
     @include media(">=notebook") {
       font-size: var(--text-size-2);
       line-height: 1.25;
     }
-  }
-
-  [data-accordion-item] [data-store-icon] {
-    display: flex;
   }
 }
 

--- a/src/components/search/Filter/filter.scss
+++ b/src/components/search/Filter/filter.scss
@@ -25,6 +25,7 @@
   }
 
   [data-accordion-item] [data-store-button] {
+    font-weight: var(--text-weight-regular);
     font-size: var(--text-size-3);
     line-height: 1.5;
 

--- a/src/components/search/Filter/filter.scss
+++ b/src/components/search/Filter/filter.scss
@@ -68,6 +68,7 @@
   button {
     position: absolute;
     right: calc(-1 * var(--page-padding-phone));
+    color: var(--color-text);
     background-color: transparent;
   }
 }

--- a/src/components/search/Filter/filter.scss
+++ b/src/components/search/Filter/filter.scss
@@ -68,6 +68,7 @@
   button {
     position: absolute;
     right: calc(-1 * var(--page-padding-phone));
+    margin-right: var(--space-0);
     color: var(--color-text);
     background-color: transparent;
   }

--- a/src/components/ui/Accordion/Accordion.tsx
+++ b/src/components/ui/Accordion/Accordion.tsx
@@ -2,6 +2,8 @@ import React, { forwardRef } from 'react'
 import { Accordion as UIAccordion } from '@faststore/ui'
 import type { AccordionProps } from '@faststore/ui'
 
+import './accordion.scss'
+
 interface Props extends Omit<AccordionProps, 'indices'> {
   /**
    * Indices that indicate which accordion items are opened.
@@ -21,6 +23,7 @@ const Accordion = forwardRef<HTMLDivElement, Props>(function Accordion(
 ) {
   return (
     <UIAccordion
+      className="accordion"
       data-store-accordion
       ref={ref}
       onChange={onChange}

--- a/src/components/ui/Accordion/AccordionItem.tsx
+++ b/src/components/ui/Accordion/AccordionItem.tsx
@@ -6,6 +6,10 @@ import {
   AccordionButton as UIAccordionButton,
 } from '@faststore/ui'
 import type { AccordionItemProps } from '@faststore/ui'
+import {
+  PlusCircle as PlusCircleIcon,
+  MinusCircle as MinusCircleIcon,
+} from 'phosphor-react'
 
 interface Props extends AccordionItemProps {
   /**
@@ -31,13 +35,13 @@ const AccordionItem = forwardRef<HTMLDivElement, Props>(function AccordionItem(
 ) {
   return (
     <UIAccordionItem
-      data-store-accordion-item
       ref={ref}
       index={index}
       data-testid={testId}
       {...otherProps}
     >
       <UIAccordionButton
+        className="title-subsection"
         data-accordion-item-button
         data-testid={`${testId}-button`}
       >
@@ -45,7 +49,13 @@ const AccordionItem = forwardRef<HTMLDivElement, Props>(function AccordionItem(
         <UIIcon
           data-accordion-item-button-icon
           data-testid={`${testId}-button-icon`}
-          component={isExpanded ? <div>-</div> : <div>+</div>}
+          component={
+            isExpanded ? (
+              <MinusCircleIcon size={24} />
+            ) : (
+              <PlusCircleIcon size={24} />
+            )
+          }
         />
       </UIAccordionButton>
       <UIAccordionPanel

--- a/src/components/ui/Accordion/AccordionItem.tsx
+++ b/src/components/ui/Accordion/AccordionItem.tsx
@@ -42,12 +42,10 @@ const AccordionItem = forwardRef<HTMLDivElement, Props>(function AccordionItem(
     >
       <UIAccordionButton
         className="title-subsection"
-        data-accordion-item-button
         data-testid={`${testId}-button`}
       >
         {buttonLabel}
         <UIIcon
-          data-accordion-item-button-icon
           data-testid={`${testId}-button-icon`}
           component={
             isExpanded ? (
@@ -58,10 +56,7 @@ const AccordionItem = forwardRef<HTMLDivElement, Props>(function AccordionItem(
           }
         />
       </UIAccordionButton>
-      <UIAccordionPanel
-        data-accordion-item-panel
-        data-testid={`${testId}-panel`}
-      >
+      <UIAccordionPanel data-testid={`${testId}-panel`}>
         {children}
       </UIAccordionPanel>
     </UIAccordionItem>

--- a/src/components/ui/Accordion/accordion.scss
+++ b/src/components/ui/Accordion/accordion.scss
@@ -1,0 +1,34 @@
+@import "../../../styles/scaffold";
+
+.accordion[data-store-accordion] {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+
+  [data-accordion-item] {
+    border-bottom: 1px solid var(--color-border-display);
+
+    @include media(">=notebook") {
+      padding: 0 var(--space-4);
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  [data-accordion-item] [data-store-button] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--space-3) 0;
+    color: var(--color-text);
+    background-color: transparent;
+    border: 0;
+  }
+
+  [data-accordion-item] [data-store-icon] {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

- Extracts accordion base style from `Footer.scss` and `Filter.scss`
- Replaces Accordion on Footer and Filter
- Visual adjusts on Filter component


PS: The Filter's footer (buttons area) still flicks a little bit on mobile, but it will be solved when we replace the Modal for the [SlideOver component](https://github.com/vtex-sites/base.store/pull/262)


## References
[FSSS-151 Styles Accordion and Replace](https://vtex-dev.atlassian.net/jira/software/projects/FSSS/boards/632?selectedIssue=FSSS-151)