### PR TITLE
[FSSS-154] Chore: order global style previously

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -81,3 +81,22 @@ export const onRenderBody = ({ setHeadComponents }) => {
     setHeadComponents([<Partytown key="partytown" forward={forward} />])
   }
 }
+
+export const onPreRenderHTML = ({
+  getHeadComponents,
+  replaceHeadComponents,
+}) => {
+  const headComponents = getHeadComponents()
+
+  // enforce the global style before the others
+  const orderedComponents = headComponents.sort((item) => {
+    const isGlobalStyle =
+      item.type === 'style' &&
+      item.props['data-href'] &&
+      /^\/styles.[a-zA-Z0-9]*.css$/.test(item.props['data-href'])
+
+    return isGlobalStyle ? -1 : 1
+  })
+
+  replaceHeadComponents(orderedComponents)
+}


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR aims to order the global style before the others (pages/components) so that we can keep the styles consistent on dev and prod environments.

## How to test it?
We can check the order of our styles into the `<head>`, global style should come before the others.
Preview: https://preview-271--base.preview.vtex.app