### PR TITLE
Fix Lighthouse PDP flaky error in console failure

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -60,7 +60,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
         type="text/partytown"
         dangerouslySetInnerHTML={{
           __html: `
-          window.sendrc=function(en,ed){window.NavigationCapture?.sendEvent(en,ed)}
+          window.sendrc=function(en,ed){window.NavigationCapture&&window.NavigationCapture.sendEvent(en,ed)};
           `,
         }}
       />,

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -60,7 +60,7 @@ export const onRenderBody = ({ setHeadComponents }) => {
         type="text/partytown"
         dangerouslySetInnerHTML={{
           __html: `
-          window.sendrc=function(en,ed){window.NavigationCapture.sendEvent(en,ed)}
+          window.sendrc=function(en,ed){window.NavigationCapture?.sendEvent(en,ed)}
           `,
         }}
       />,


### PR DESCRIPTION
## What's the purpose of this pull request?

Sometimes PDP's Lighthouse check will fail due to [errors being logged to the browser's console](https://github.com/vtex-sites/base.store/runs/4899927947#:~:text=%E2%9C%98-,errors%2Din%2Dconsole,-failure%20for%20minScore):

> TypeError: Cannot read properties of undefined (reading 'sendEvent')
at Proxy.window.sendrc (eval at le (077a6614-0b37-4599-9ad7-70338f3e2ddb:2:3612), <anonymous>:4:66)
> 
> https://base.vtex.app/sleek-metal-pizza-24041857/p/
![CleanShot 2022-01-25 at 13 35 24](https://user-images.githubusercontent.com/381395/151019146-790cc971-47b4-4c21-8aa9-5dad5c07d44a.png) 

## How to test it?

Visit this PDP for the [previous version](https://sfj-63cf751--base.preview.vtex.app/sleek-metal-pizza-24041857/p/) and you should see an error on the console. Compare to the PDP in the [next version](https://sfj-97024cd--base.preview.vtex.app/sleek-metal-pizza-24041857/p/) and the error is gone.

[Before](https://sfj-63cf751--base.preview.vtex.app/sleek-metal-pizza-24041857/p/)|[After](https://sfj-97024cd--base.preview.vtex.app/sleek-metal-pizza-24041857/p/)
-|-
![CleanShot 2022-01-25 at 13 32 46](https://user-images.githubusercontent.com/381395/151018774-6e13a8d0-94e0-468f-9ca6-f0a5fc32ea21.png)|![CleanShot 2022-01-25 at 13 33 29](https://user-images.githubusercontent.com/381395/151018789-87a98235-c20d-4065-940d-0b71eeeab36f.png)


## References

- https://github.com/vtex-sites/base.store/pull/185