### PR TITLE
Fix: MiniCart - Empty State

### DIFF
--- a/src/components/cart/CartSidebar/CartSidebar.tsx
+++ b/src/components/cart/CartSidebar/CartSidebar.tsx
@@ -64,7 +64,7 @@ function CartSidebar() {
           </div>
 
           {isEmpty ? (
-            <EmptyCart />
+            <EmptyCart onDismiss={() => onDismissTransition()} />
           ) : (
             <div className="cart-sidebar__items">
               {items.map((item) => (

--- a/src/components/cart/EmptyCart/EmptyCart.tsx
+++ b/src/components/cart/EmptyCart/EmptyCart.tsx
@@ -1,20 +1,24 @@
 import React from 'react'
 import Button from 'src/components/ui/Button'
 import { ShoppingCart as ShoppingCartIcon } from 'phosphor-react'
-import { useCartToggleButton } from 'src/sdk/cart/useCartToggleButton'
 
 import './empty-cart.scss'
 
-function EmptyCart() {
-  const toggleProps = useCartToggleButton()
+interface Props {
+  /**
+   * This function is called when `Start Shopping` button is clicked
+   */
+  onDismiss: () => void
+}
 
+function EmptyCart({ onDismiss }: Props) {
   return (
     <div data-testid="cart-empty-state" data-empty-cart>
       <div data-empty-cart-title>
         <ShoppingCartIcon size="32" />
         <p>Your Cart is empty</p>
       </div>
-      <Button {...toggleProps} variant="primary">
+      <Button onClick={onDismiss} variant="primary">
         Start Shopping
       </Button>
     </div>


### PR DESCRIPTION
## What's the purpose of this pull request?
- Pass `onDismiss` function for `EmptyState` component, so who controls what to do when `Start Shopping` is clicked is the parent.
- It fixes the "locked" layout issue.

|Before|
|-|
![before](http://g.recordit.co/FwdK8eQjAr.gif)

|After|
|-|
![after](http://g.recordit.co/VXnvnMML0r.gif)

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
Open MiniCart and press `Start Shopping`. Now try to scroll the page.
