### PR TITLE
Fix: Fixes css example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,11 @@ function Button({ variant, ...props }: Props) {
 ```
 
 ```css
-.primary [data-store-button] {
+.primary[data-store-button] {
   background: blue;
 }
 
-.secondary [data-store-button] {
+.secondary[data-store-button] {
   background: pink;
 }
 ```


### PR DESCRIPTION
## What's the purpose of this pull request?
- Updates css example on readme file.
- There is no space between the class and the data-atribute 
- It should be:

```css
.primary[data-store-button] {
  background: blue;
}

.secondary[data-store-button] {
  background: pink;
}
```
