### PR TITLE
Fix a SonarQube warning

### DIFF
--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -36,9 +36,8 @@ export function QuantitySelector({
 
   function validateQuantityBounds(n: number): number {
     const maxValue = min ? Math.max(n, min) : n
-    const minValue = max ? Math.min(maxValue, max) : maxValue
 
-    return minValue
+    return max ? Math.min(maxValue, max) : maxValue
   }
 
   function validateInput(e: React.FormEvent<HTMLInputElement>) {


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix a [SonarQube warning](https://github.com/vtex-sites/base.store/runs/5025104180#:~:text=15M/61M%0AINFO%3A%20%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D%2D-,ANNOTATIONS,-Check%20warning%20on) in a piece of the code by following its suggestion of removing a temporary variable.

## How to test it?

The last commit should not have SonarQube trigger the warning anymore.

Before|After
-|-
![Screen Shot 2022-02-01 at 16 42 27](https://user-images.githubusercontent.com/381395/152039613-343f1236-ac76-4dcc-9a73-48ce992f92bf.png)|![Screen Shot 2022-02-01 at 16 42 31](https://user-images.githubusercontent.com/381395/152039598-958c00b8-5041-4f6d-aa8e-b3e93999bec3.png)
