### PR TITLE
fix: bump nginx plugin version to unbreak store

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@faststore/sdk": "^1.4.15",
     "@faststore/ui": "^1.4.15",
     "@loadable/component": "^5.15.2",
-    "@vtex/gatsby-plugin-nginx": "^1.4.15",
+    "@vtex/gatsby-plugin-nginx": "^1.4.23",
     "@vtex/gatsby-plugin-thumbor": "^1.4.15",
     "@vtex/gatsby-source-store": "^1.4.15",
     "@vtex/graphql-utils": "^1.4.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,10 +3009,10 @@
   resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.0.tgz#d3b707e0aba3111719f941dacb2408eff3c27319"
   integrity sha512-1Dy3BdOliDwxA7VZSIg55E1d/us2KvsCQOZV25fgufG//CsnZBGiSAL7qewTQf7YVHH0A9PHgzwMmKIZ8aFYVw==
 
-"@vtex/gatsby-plugin-nginx@^1.4.15":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-plugin-nginx/-/gatsby-plugin-nginx-1.4.15.tgz#f0d8ff637e1ecf6225fbaabe0aa14fa387935bd7"
-  integrity sha512-85Tfkh4TXR8YVYYdHWSrk3inpHHX8tXxkBALtQvb8MAXdQfva+v/fPBqyu/Aj1GnS8vTFm2KHClfhBi5GPRQ6A==
+"@vtex/gatsby-plugin-nginx@^1.4.23":
+  version "1.4.23"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-plugin-nginx/-/gatsby-plugin-nginx-1.4.23.tgz#db505b117be2abe32e09fefee03fd32cbeb9d91f"
+  integrity sha512-ZCVCAUxzx2PsZJgAfqwpfo5fuv8n5Vv4hKt32yWNfquUQEC/ob4VdZqf9JkHXN42buQ2RibbhAdSE7ivsd3BwQ==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^5.0.6"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR bumps the version of the nginx plugin so the build doesn't break
