### PR TITLE
[FSSS-164] Extract UISelect from Sort to its own component

### DIFF
--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -23,7 +23,7 @@ function Sort() {
 
   return (
     <Select
-      className="sort / title-small"
+      classes="sort / title-small"
       labelText="Sort by"
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -28,7 +28,6 @@ function Sort() {
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}
       value={sort}
-      aria-label="Product Sort"
       testId="search-sort"
     />
   )

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -23,6 +23,7 @@ function Sort() {
 
   return (
     <Select
+      id="sort-select"
       classes="sort / title-small"
       labelText="Sort by"
       options={OptionsMap}

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -1,9 +1,6 @@
 import { useSearch } from '@faststore/sdk'
 import React from 'react'
-import { Select as UISelect } from '@faststore/ui'
-import { CaretDown as CaretDownIcon } from 'phosphor-react'
-
-import './sort.scss'
+import Select from 'src/components/ui/Select'
 
 const OptionsMap = {
   price_desc: 'Price, descending',
@@ -25,23 +22,15 @@ function Sort() {
   } = useSearch()
 
   return (
-    <div className="sort / title-small">
-      <label htmlFor="select-sort">Sort by</label>
-      <UISelect
-        data-testid="search-sort"
-        onChange={(e) => setSort(keys[e.target.selectedIndex])}
-        value={sort}
-        aria-label="Product Sort"
-        id="select-sort"
-      >
-        {keys.map((key) => (
-          <option key={key} value={key}>
-            {OptionsMap[key]}
-          </option>
-        ))}
-      </UISelect>
-      <CaretDownIcon size={18} weight="bold" />
-    </div>
+    <Select
+      className="sort / title-small"
+      labelText="Sort by"
+      options={OptionsMap}
+      onChange={(e) => setSort(keys[e.target.selectedIndex])}
+      value={sort}
+      aria-label="Product Sort"
+      testId="search-sort"
+    />
   )
 }
 

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -24,7 +24,7 @@ function Sort() {
   return (
     <Select
       id="sort-select"
-      classes="sort / title-small"
+      className="sort / title-small"
       labelText="Sort by"
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -12,10 +12,6 @@ interface UISelectProps extends SelectProps {
    */
   id: string
   /*
-   * Defines the CSS class string that will be forwarded to the wrapping div "className" prop.
-   */
-  classes?: string
-  /*
    * Defines the options available in the select. The SelectOptions object
    * keys are the property names, while the values correspond to the text that
    * will be displayed in the UI
@@ -30,16 +26,16 @@ interface UISelectProps extends SelectProps {
 
 export default function Select({
   id,
+  className,
   options,
   onChange,
   labelText,
   value,
   'aria-label': ariaLabel,
-  classes,
   testId,
 }: UISelectProps) {
   return (
-    <div data-select className={classes}>
+    <div data-select className={className}>
       {labelText && <label htmlFor={id}>{labelText}</label>}
       <UISelect
         data-testid={testId}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -16,7 +16,7 @@ interface UISelectProps extends SelectProps {
   classes?: string
   /*
    * Defines the options available in the select. The SelectOptions object
-   * keys are the property names, while the values correspond  to the text that
+   * keys are the property names, while the values correspond to the text that
    * will be displayed in the UI
    */
   options: SelectOptions

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -11,6 +11,10 @@ type SelectOptions = {
 
 interface UISelectProps extends SelectProps {
   /*
+   * Defines the CSS class string that will be forwarded to the wrapping div "className" prop.
+   */
+  classes?: string
+  /*
    * Defines the options available in the select. The SelectOptions object
    * keys are the property names, while the values correspond  to the text that
    * will be displayed in the UI
@@ -29,11 +33,11 @@ export default function Select({
   labelText,
   value,
   'aria-label': ariaLabel,
-  className,
+  classes,
   testId,
 }: UISelectProps) {
   return (
-    <div data-select className={className}>
+    <div data-select className={classes}>
       {labelText && <label htmlFor="ui-select">{labelText}</label>}
       <UISelect
         data-testid={testId}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Select as UISelect } from '@faststore/ui'
+import type { SelectProps } from '@faststore/ui'
+import { CaretDown as CaretDownIcon } from 'phosphor-react'
+
+import './select.scss'
+
+type SelectOptions = {
+  [key: string]: string
+}
+
+interface UISelectProps extends SelectProps {
+  /*
+   * Defines the options available in the select. The SelectOptions object
+   * keys are the property names, while the values correspond  to the text that
+   * will be displayed in the UI
+   */
+  options: SelectOptions
+  /*
+   * Specifies the text that will be displayed in the label right next to the Select.
+   * If omitted, the label will not be rendered.
+   */
+  labelText?: string
+}
+
+export default function Select({
+  options,
+  onChange,
+  labelText,
+  value,
+  'aria-label': ariaLabel,
+  className,
+  testId,
+}: UISelectProps) {
+  return (
+    <div data-ui-select className={className}>
+      {labelText && <label htmlFor="ui-select">{labelText}</label>}
+      <UISelect
+        data-testid={testId}
+        onChange={onChange}
+        value={value}
+        aria-label={ariaLabel}
+        id="ui-select"
+      >
+        {Object.keys(options).map((key) => (
+          <option key={key} value={key}>
+            {options[key]}
+          </option>
+        ))}
+      </UISelect>
+      <CaretDownIcon size={18} weight="bold" />
+    </div>
+  )
+}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -33,7 +33,7 @@ export default function Select({
   testId,
 }: UISelectProps) {
   return (
-    <div data-ui-select className={className}>
+    <div data-select className={className}>
       {labelText && <label htmlFor="ui-select">{labelText}</label>}
       <UISelect
         data-testid={testId}

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -11,6 +11,11 @@ type SelectOptions = {
 
 interface UISelectProps extends SelectProps {
   /*
+   * Redefines the id property to be required when using the Select component. The
+   * id will be used to link the UISelect component and its label.
+   */
+  id: string
+  /*
    * Defines the CSS class string that will be forwarded to the wrapping div "className" prop.
    */
   classes?: string
@@ -28,6 +33,7 @@ interface UISelectProps extends SelectProps {
 }
 
 export default function Select({
+  id,
   options,
   onChange,
   labelText,
@@ -38,13 +44,13 @@ export default function Select({
 }: UISelectProps) {
   return (
     <div data-select className={classes}>
-      {labelText && <label htmlFor="ui-select">{labelText}</label>}
+      {labelText && <label htmlFor={id}>{labelText}</label>}
       <UISelect
         data-testid={testId}
         onChange={onChange}
         value={value}
         aria-label={ariaLabel}
-        id="ui-select"
+        id={id}
       >
         {Object.keys(options).map((key) => (
           <option key={key} value={key}>

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -5,10 +5,6 @@ import { CaretDown as CaretDownIcon } from 'phosphor-react'
 
 import './select.scss'
 
-type SelectOptions = {
-  [key: string]: string
-}
-
 interface UISelectProps extends SelectProps {
   /*
    * Redefines the id property to be required when using the Select component. The
@@ -24,7 +20,7 @@ interface UISelectProps extends SelectProps {
    * keys are the property names, while the values correspond to the text that
    * will be displayed in the UI
    */
-  options: SelectOptions
+  options: Record<string, string>
   /*
    * Specifies the text that will be displayed in the label right next to the Select.
    * If omitted, the label will not be rendered.

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Select'

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/scaffold.scss";
 
-[data-ui-select] {
+[data-select] {
   position: relative;
   display: flex;
   align-items: center;

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/scaffold.scss";
 
-.sort {
+[data-ui-select] {
   position: relative;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR extracts the UISelect component that was being used by the Sort component internally to its own component.

## How it works? 
This essentially:
- Removes the `sort.scss` stylesheet completely
- Move all styles to the `select.scss` stylesheet
- Adds a new `Select` component that wraps the `UISelect` from faststore
  - It uses the `id` attribute to link the `label` component with the `UISelect`
  - If it receives a `className` attribute, it will forward that attribute to the `className` prop in the outer div. Optional.
  - If it receives a `labelText` attribute, it will render a label together with the select. Optional.
  - It forwards the `aria-label` attribute to the `UISelect` `aria-label`. This attribute is required.
  - It receives an `options` attribute which is a `Record<string, string>` so it can build the available options that will be displayed when the user clicks the Select component. This attribute is required.

## How to test it?
`yarn test`
Verify that all the tests still pass, so the original behaviour is kept.

Also open the local instance and verify that no styles are broken, meaning the change did not affect the styles as well.

## References
Thanks to @renatamottam 
