### PR TITLE
[FSSS-124] Fix sentinel

### DIFF
--- a/cypress/integration/plp.test.js
+++ b/cypress/integration/plp.test.js
@@ -144,8 +144,8 @@ describe('Infinite Scroll pagination', () => {
 
         cy.getById('show-more')
           .should('exist')
-          .scrollIntoView({ offset: { top: 50 }, duration: 100 })
-          .click({ force: true })
+          .scrollIntoView({ duration: 500 })
+          .click()
           .then(() => {
             // Ensure it waits for the new page after clicking "show more"
             cy.location('search').should('match', /page=1$/)
@@ -185,13 +185,13 @@ describe('Infinite Scroll pagination', () => {
     cy.waitForHydration()
 
     cy.getById('show-more')
-      .should('exist')
-      .click({ force: true })
+      .scrollIntoView({ duration: 500 })
+      .click()
       .then(() => {
         // Scroll to the last product and confirm that we are on page 1
         cy.get('.product-grid [data-testid=store-card]')
           .last()
-          .scrollIntoView({ offset: { top: 50 } })
+          .scrollIntoView({ duration: 500 })
           .then(() => {
             cy.location('search').should('match', /page=1$/)
           })
@@ -199,7 +199,7 @@ describe('Infinite Scroll pagination', () => {
         // Scroll back to the first product and confirm that we are on page 0
         cy.get('.product-grid [data-testid=store-card]')
           .first()
-          .scrollIntoView({ offset: { top: -50 } })
+          .scrollIntoView({ duration: 500 })
           .then(() => {
             cy.location('search').should('match', /page=0$/)
           })

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -37,9 +37,7 @@ function handlePageFocus() {
     const allSentinels = document.querySelectorAll('[data-sentinel=false]')
 
     if (allSentinels.length > 0) {
-      allSentinels[allSentinels.length - 1].scrollIntoView({
-        behavior: 'smooth',
-      })
+      allSentinels[allSentinels.length - 1].scrollIntoView()
     }
   }
 }

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -1,6 +1,6 @@
 import { usePagination, useSearch } from '@faststore/sdk'
 import { GatsbySeo } from 'gatsby-plugin-next-seo'
-import React, { useState, lazy, Suspense } from 'react'
+import React, { useState, lazy, Suspense, useEffect } from 'react'
 import Button, { LinkButton } from 'src/components/ui/Button'
 import Sort from 'src/components/search/Sort'
 import useWindowDimensions from 'src/hooks/useWindowDimensions'
@@ -23,6 +23,27 @@ interface Props {
   slug?: string
 }
 
+/*
+ * Method that handles an edge case of pagination: when user clicks to
+ * load more products at the bottom of the page, this logic takes care of
+ * reading the rendered sentinels (one per page) state, and, if no sentinel
+ * is currently in view, the page scrolls back to the last sentinel
+ * (that is, the page that just loaded.)
+ */
+function handlePageFocus() {
+  const sentinelsInView = document.querySelectorAll('[data-sentinel=true]')
+
+  if (sentinelsInView.length === 0) {
+    const allSentinels = document.querySelectorAll('[data-sentinel=false]')
+
+    if (allSentinels.length > 0) {
+      allSentinels[allSentinels.length - 1].scrollIntoView({
+        behavior: 'smooth',
+      })
+    }
+  }
+}
+
 function ProductGallery({ title, slug }: Props) {
   const { pages, state: searchState, addNextPage, addPrevPage } = useSearch()
   const { data } = useGalleryQuery()
@@ -35,6 +56,10 @@ function ProductGallery({ title, slug }: Props) {
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false)
 
   const orderedFacets = useOrderedFacets(data)
+
+  useEffect(() => {
+    handlePageFocus()
+  }, [searchState])
 
   return (
     <>

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -63,13 +63,12 @@ function GalleryPage({
     productsSponsored.length > 1
 
   return (
-    <>
-      <Sentinel
-        products={products}
-        page={page}
-        pageSize={itemsPerPage}
-        title={title}
-      />
+    <Sentinel
+      products={products}
+      page={page}
+      pageSize={itemsPerPage}
+      title={title}
+    >
       {shouldDisplaySponsoredProducts ? (
         <>
           <ProductGrid
@@ -100,7 +99,7 @@ function GalleryPage({
           />
         </Suspense>
       )}
-    </>
+    </Sentinel>
   )
 }
 

--- a/src/sdk/search/Sentinel.tsx
+++ b/src/sdk/search/Sentinel.tsx
@@ -44,6 +44,14 @@ function Sentinel({
 }: PropsWithChildren<Props>) {
   const viewedRef = useRef(false)
   const { ref, inView } = useInView({
+    /*
+     * Defines extra breakpoints on the children that will be wrapped
+     * by the Sentinel. This helps on infinite pagination when scrolling
+     * up and down between pages, making the page updates smoother and
+     * more precise. We add more granular breakpoints at the edges so it
+     * handles better the page edges (when only just a tiny bit of the page
+     * is entering or leaving the view)
+     */
     threshold: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
   })
 

--- a/src/sdk/search/Sentinel.tsx
+++ b/src/sdk/search/Sentinel.tsx
@@ -1,4 +1,5 @@
 import { useSearch } from '@faststore/sdk'
+import type { PropsWithChildren } from 'react'
 import React, { useEffect, useRef } from 'react'
 import { useInView } from 'react-intersection-observer'
 import type { ProductSummary_ProductFragment } from '@generated/graphql'
@@ -34,9 +35,18 @@ const replacePagination = (page: number) => {
  * Also, this component's name is kind of curious. Wikipedia calls is Page Break(https://en.wikipedia.org/wiki/Page_break)
  * however all codes I've seen online use Sentinel
  */
-function Sentinel({ page, pageSize, products, title }: Props) {
+function Sentinel({
+  children,
+  page,
+  pageSize,
+  products,
+  title,
+}: PropsWithChildren<Props>) {
   const viewedRef = useRef(false)
-  const { ref, inView } = useInView()
+  const { ref, inView } = useInView({
+    threshold: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+  })
+
   const { state: searchState, pages } = useSearch()
 
   const { sendViewItemListEvent } = useViewItemListEvent({
@@ -59,7 +69,11 @@ function Sentinel({ page, pageSize, products, title }: Props) {
     }
   }, [inView, page, pages.length, searchState, sendViewItemListEvent])
 
-  return <div ref={ref} />
+  return (
+    <div data-sentinel={inView} ref={ref}>
+      {children}
+    </div>
+  )
 }
 
 export default Sentinel

--- a/src/sdk/search/Sentinel.tsx
+++ b/src/sdk/search/Sentinel.tsx
@@ -48,11 +48,14 @@ function Sentinel({
      * Defines extra breakpoints on the children that will be wrapped
      * by the Sentinel. This helps on infinite pagination when scrolling
      * up and down between pages, making the page updates smoother and
-     * more precise. We add more granular breakpoints at the edges so it
-     * handles better the page edges (when only just a tiny bit of the page
-     * is entering or leaving the view)
+     * more precise. We add more granular breakpoints at the edges for
+     * compatibility with mobile devices, where less content is shown on
+     * screen and higher thresholds are harder to reach.
      */
-    threshold: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+    threshold: [
+      0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+      0.95, 0.96, 0.97, 0.98, 0.99, 1,
+    ],
   })
 
   const { state: searchState, pages } = useSearch()

--- a/src/sdk/search/Sentinel.tsx
+++ b/src/sdk/search/Sentinel.tsx
@@ -43,20 +43,7 @@ function Sentinel({
   title,
 }: PropsWithChildren<Props>) {
   const viewedRef = useRef(false)
-  const { ref, inView } = useInView({
-    /*
-     * Defines extra breakpoints on the children that will be wrapped
-     * by the Sentinel. This helps on infinite pagination when scrolling
-     * up and down between pages, making the page updates smoother and
-     * more precise. We add more granular breakpoints at the edges for
-     * compatibility with mobile devices, where less content is shown on
-     * screen and higher thresholds are harder to reach.
-     */
-    threshold: [
-      0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
-      0.95, 0.96, 0.97, 0.98, 0.99, 1,
-    ],
-  })
+  const { ref, inView } = useInView()
 
   const { state: searchState, pages } = useSearch()
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR revisits `Sentinel` implementation to enhance/fix some of its behavior.

## How does it work?
- It modifies the `Sentinel` to wrap around a product list page by making it accept other components as `children`. This way we can have a better control of page switching when scrolling up and down.
- It adds an `useEffect` hook to handle an edge case of pagination: When we click to load more items but there are no products (and therefore no sentinels) on screen - This was making the pagination behave weirdly.
- [WIP] It enhances the `plp` tests by getting rid of the forced clicks and offsets, that were only a workaround for the sentinel's limitations.

## How to test it?
Go to the PLP, scroll up and down, load products, play a little.
Run `yarn test`, verify that everything passes.

**[Bug Found]**: When scrolling down the PLP, stop right when the pagination changes. Now start scrolling up back to the page you were. Note that the page _**does not**_ change. This happens because the hook only updates pagination when the `inView` for a `Sentinel` changes. On this scenario, neither the upper nor the bottom sentinel had changes on their view status, so pagination is not updated. Not sure how to solve this yet.

## References
Big praise and thanks to @hellofanny 
