### PR TITLE
chore: Simplify pages redirects and fixes warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder
 
 ### Deprecated
 
 ### Removed
+- API style redirects from `/_v/private/graphql` since they have no effect
 
 ### Fixed
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,10 +2,6 @@ const path = require('path')
 
 const fs = require('fs-extra')
 
-const config = require('./store.config')
-
-const { secureSubdomain, loginUrl, accountUrl } = config
-
 exports.onPreInit = ({ reporter }) => {
   reporter.info('Copying Partytown Files')
 
@@ -58,51 +54,5 @@ exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
     name: `@vtex/graphql-utils/babel`,
     options: {},
-  })
-}
-
-exports.createPages = async ({ actions: { createRedirect } }) => {
-  createRedirect({
-    fromPath: '/login/',
-    toPath: loginUrl,
-    statusCode: 301,
-    redirectInBrowser: true,
-  })
-
-  createRedirect({
-    fromPath: '/account/',
-    toPath: accountUrl,
-    statusCode: 301,
-    redirectInBrowser: true,
-  })
-
-  createRedirect({
-    fromPath: '/_v/private/graphql/*',
-    toPath: `${secureSubdomain}/_v/private/graphql/:splat`,
-    statusCode: 301,
-  })
-
-  createRedirect({
-    fromPath: '/_v/public/graphql/*',
-    toPath: `${secureSubdomain}/_v/public/graphql/:splat`,
-    statusCode: 301,
-  })
-
-  createRedirect({
-    fromPath: '/_v/segment/graphql/*',
-    toPath: `${secureSubdomain}/_v/segment/graphql/:splat`,
-    statusCode: 301,
-  })
-
-  createRedirect({
-    fromPath: '/api/vtexid/*',
-    toPath: `${secureSubdomain}/api/vtexid/:splat`,
-    statusCode: 301,
-  })
-
-  createRedirect({
-    fromPath: '/api/sessions/*',
-    toPath: `${secureSubdomain}/api/sessions/:splat`,
-    statusCode: 301,
   })
 }

--- a/src/pages/checkout.tsx
+++ b/src/pages/checkout.tsx
@@ -5,7 +5,7 @@ import storeConfig from '../../store.config'
 
 function Page() {
   useEffect(() => {
-    window.location.href = storeConfig.accountUrl
+    window.location.href = storeConfig.checkoutUrl
   }, [])
 
   return (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -5,7 +5,7 @@ import storeConfig from '../../store.config'
 
 function Page() {
   useEffect(() => {
-    window.location.href = storeConfig.accountUrl
+    window.location.href = storeConfig.loginUrl
   }, [])
 
   return (


### PR DESCRIPTION
## What's the purpose of this pull request?
We were doing two kinds of redirects. The first one was a pages redirects, a.k.a /account -> storeframework.myvtex.com/account and the second one was an api redirect, a.k.a /_v/private/graphql to storeframework.myvtex.com/_v/private/graphql. 

The API redirect kind makes no sense for me, since these requests should ALWAYS be made on the myvtex.com domain, so the main store's domain should never receive any request for these apis, so I've removed them

Also, I think page redirects type can be done in a better way. Redirects are platform/framework dependent and are not easy to port to other frameworks/platforms. To avoid this, we can do a react-based redirect on the browser, with the benefit of improving SEO by adding the right tags to these pages, which is not usually the case on other VTEX's services. For instance, VTEX does not add the right no-index/no-follow tags to the `/checkout` page in checkout-ui v6.
 
One nice side effect is that the whole page structure is now located inside the `/pages` folder

Also, this PR fixes the warning:
```
warn There are routes that match both page and redirect. Pages take precendence over redirects so the redirect will not work:
 - page: "/account/" and redirect: "/account/" -> "https://secure.vtexfaststore.com/api/io/account"
 ```