### PR TITLE
fix: Partial hydration issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browserslist": "supports es6-module and not dead",
   "scripts": {
     "generate": "graphql-codegen",
-    "build": "gatsby build --log-pages",
+    "build": "gatsby build",
     "develop": "gatsby develop",
     "clean": "gatsby clean",
     "serve": "gatsby serve",

--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { List as UIList } from '@faststore/ui'
-import useWindowDimensions from 'src/hooks/useWindowDimensions'
 
 import Link from '../../ui/Link'
 import Accordion, { AccordionItem } from '../../ui/Accordion'
@@ -108,7 +107,6 @@ function LinksList({ items }: LinksListProps) {
 }
 
 function FooterLinks() {
-  const { isMobile } = useWindowDimensions()
   const [indicesExpanded, setIndicesExpanded] = useState<Set<number>>(
     new Set([])
   )
@@ -124,7 +122,7 @@ function FooterLinks() {
 
   return (
     <section className="footer__links">
-      {isMobile ? (
+      <div className="display-mobile">
         <Accordion expandedIndices={indicesExpanded} onChange={onChange}>
           {links.map((section, index) => (
             <AccordionItem
@@ -136,16 +134,16 @@ function FooterLinks() {
             </AccordionItem>
           ))}
         </Accordion>
-      ) : (
-        <div className="footer__links-columns">
-          {links.map((section) => (
-            <nav key={section.title}>
-              <p className="title-sub-subsection">{section.title}</p>
-              <LinksList items={section.items} />
-            </nav>
-          ))}
-        </div>
-      )}
+      </div>
+
+      <div className="hidden-mobile footer__links-columns">
+        {links.map((section) => (
+          <nav key={section.title}>
+            <p className="title-sub-subsection">{section.title}</p>
+            <LinksList items={section.items} />
+          </nav>
+        ))}
+      </div>
     </section>
   )
 }

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -8,7 +8,6 @@ import IconButton from 'src/components/ui/IconButton'
 import { List as ListIcon, X as XIcon } from 'phosphor-react'
 import SignInLink from 'src/components/ui/SignInLink'
 import SlideOver from 'src/components/ui/SlideOver'
-import useWindowDimensions from 'src/hooks/useWindowDimensions'
 
 import SearchInput from '../SearchInput'
 
@@ -43,7 +42,6 @@ function NavLinks() {
 
 function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
-  const { isMobile } = useWindowDimensions()
   let onDismissTransition: () => unknown
 
   return (
@@ -72,47 +70,46 @@ function Navbar() {
         </section>
         <NavLinks />
       </div>
-      {isMobile && (
-        <SlideOver
-          isOpen={showMenu}
-          onDismiss={() => setShowMenu(false)}
-          onDismissTransition={(callback) => (onDismissTransition = callback)}
-          size="full"
-          direction="leftSide"
-          className="navbar__modal-content"
-        >
-          <div className="navbar__modal-body">
-            <header className="navbar__modal-header">
-              <LinkGatsby
-                to="/"
-                aria-label="Go to Faststore home"
-                title="Go to Faststore home"
-                className="navbar__logo"
-                onClick={() => {
-                  onDismissTransition?.()
-                }}
-              >
-                <Logo />
-              </LinkGatsby>
 
-              <IconButton
-                classes="navbar__button"
-                aria-label="Close Menu"
-                icon={<XIcon size={32} />}
-                onClick={() => {
-                  onDismissTransition?.()
-                }}
-              />
-            </header>
-            <div className="navlinks">
-              <NavLinks />
-              <div className="navlinks__signin">
-                <SignInLink />
-              </div>
+      <SlideOver
+        isOpen={showMenu}
+        onDismiss={() => setShowMenu(false)}
+        onDismissTransition={(callback) => (onDismissTransition = callback)}
+        size="full"
+        direction="leftSide"
+        className="navbar__modal-content"
+      >
+        <div className="navbar__modal-body">
+          <header className="navbar__modal-header">
+            <LinkGatsby
+              to="/"
+              aria-label="Go to Faststore home"
+              title="Go to Faststore home"
+              className="navbar__logo"
+              onClick={() => {
+                onDismissTransition?.()
+              }}
+            >
+              <Logo />
+            </LinkGatsby>
+
+            <IconButton
+              classes="navbar__button"
+              aria-label="Close Menu"
+              icon={<XIcon size={32} />}
+              onClick={() => {
+                onDismissTransition?.()
+              }}
+            />
+          </header>
+          <div className="navlinks">
+            <NavLinks />
+            <div className="navlinks__signin">
+              <SignInLink />
             </div>
           </div>
-        </SlideOver>
-      )}
+        </div>
+      </SlideOver>
     </header>
   )
 }

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -3,7 +3,6 @@ import { GatsbySeo } from 'gatsby-plugin-next-seo'
 import React, { useState, lazy, Suspense } from 'react'
 import Button, { LinkButton } from 'src/components/ui/Button'
 import Sort from 'src/components/search/Sort'
-import useWindowDimensions from 'src/hooks/useWindowDimensions'
 import {
   FadersHorizontal as FadersHorizontalIcon,
   ArrowLeft as ArrowLeftIcon,
@@ -30,7 +29,6 @@ function ProductGallery({ title, slug }: Props) {
   const totalCount = useTotalCount(data)
 
   const { next, prev } = usePagination(totalCount)
-  const { isMobile } = useWindowDimensions()
 
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false)
 
@@ -60,18 +58,17 @@ function ProductGallery({ title, slug }: Props) {
       <div className="product-listing__sort">
         <Sort />
 
-        {isMobile && (
-          <Button
-            variant="tertiary"
-            data-testid="open-filter-button"
-            icon={<FadersHorizontalIcon size={16} />}
-            iconPosition="left"
-            aria-label="Open Filters"
-            onClick={() => setIsFilterOpen(!isFilterOpen)}
-          >
-            Filters
-          </Button>
-        )}
+        <Button
+          className="button display-mobile"
+          variant="tertiary"
+          data-testid="open-filter-button"
+          icon={<FadersHorizontalIcon size={16} />}
+          iconPosition="left"
+          aria-label="Open Filters"
+          onClick={() => setIsFilterOpen(!isFilterOpen)}
+        >
+          Filters
+        </Button>
       </div>
 
       <div className="product-listing__results">

--- a/src/components/ui/SlideOver/SlideOver.tsx
+++ b/src/components/ui/SlideOver/SlideOver.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useRef } from 'react'
 import type { ReactNode, HTMLAttributes } from 'react'
 import { Modal as UIModal } from '@faststore/ui'
 
@@ -33,26 +33,30 @@ const SlideOver = ({
   children,
   ...otherProps
 }: SlideOverProps) => {
+  const layout = useRef<HTMLElement | null>(null)
   const [fadeType, setFadeType] = useState<FadeType>()
-  const layout = document.getElementById('layout')
 
   const handleClose = useCallback(() => {
     setFadeType('out')
-    if (layout) {
-      layout.classList.remove('no-scroll')
+    if (layout.current) {
+      layout.current.classList.remove('no-scroll')
     }
-  }, [layout])
+  }, [])
+
+  useEffect(() => {
+    layout.current = document.getElementById('layout')
+  })
 
   useEffect(() => {
     if (isOpen) {
       setFadeType('in')
 
       // Avoids double scroll issue on the page
-      if (layout) {
-        layout.classList.add('no-scroll')
+      if (layout.current) {
+        layout.current.classList.add('no-scroll')
       }
     }
-  }, [isOpen, layout])
+  }, [isOpen])
 
   useEffect(() => {
     if (handleClose) {

--- a/src/sdk/tests/index.tsx
+++ b/src/sdk/tests/index.tsx
@@ -12,10 +12,9 @@ let renders = 0
 function TestProvider({ children }: PropsWithChildren<unknown>) {
   const [id, setId] = useState('')
 
-  renders++
-
   useEffect(() => {
     setId('react-hydrated')
+    renders++
   }, [])
 
   return (

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -129,3 +129,19 @@
   left: 0;
   overflow: hidden;
 }
+
+.hidden-mobile {
+  display: none;
+
+  @include media(">=notebook") {
+    display: block;
+  }
+}
+
+.display-mobile {
+  display: block;
+
+  @include media(">=notebook") {
+    display: none;
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?
Doing SSR with React is quite tricky. Client code should render exactly the same html that the server render to the hydration process occurs with no mismatches. To learn more about this problem, take a look at [React's docs](https://reactjs.org/docs/react-dom.html#hydrate)

This PR fixes a few of these mismatches by purging the `useWindowDimensions`  hook. 

## How does it work?
`useWindowDimensions` was being used to decide wether or not to render a mobile/desktop version of the component. This hook works great if the component is being rendered on the client side. However, this hook was being run during SSR, which caused a mismatch to occur if the device opening the page differs from the default one. 

This PR fixes this issue by removing this hook and adding two css classes, `hidden-mobile` and `display-mobile`. These serve as barriers and add a `display: none` in case of mobile or different than mobile respectively. In the end, this adds a bigger html footprint, but as of today, there is no better approach in the react world using Jamstack. 

## How to test it?
Nothing visual should have changed.
