### PR TITLE
chore: remove pages logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browserslist": "supports es6-module and not dead",
   "scripts": {
     "generate": "graphql-codegen",
-    "build": "gatsby build --log-pages",
+    "build": "gatsby build",
     "develop": "gatsby develop",
     "clean": "gatsby clean",
     "serve": "gatsby serve",


### PR DESCRIPTION
## What's the purpose of this pull request?
When building pages we get lots and lots of logs. This removes the logs a little bit for better build report
