### PR TITLE
fix: PLP complexity

### DIFF
--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -2,7 +2,7 @@
 
 // Check it after apply Skeletons.
 .product-listing__data-loading {
-  --product-listing-grid-height: 2197px;
+  --product-listing-grid-height: 1164px;
   --product-listing-row-height: var(--space-6);
 
   min-height: calc(var(--product-listing-grid-height) - var(--product-listing-row-height));
@@ -59,11 +59,8 @@
 // Check it after apply Skeletons.
 .product-listing__results {
   --padding: var(--space-1);
-  --product-listing-grid-height: 2197px;
-  --product-listing-row-height: var(--space-6);
 
   order: 3;
-  min-height: calc(var(--product-listing-grid-height) - var(--product-listing-row-height));
   padding: var(--padding) var(--padding) 0;
   background-color: var(--bg-neutral-light);
 

--- a/src/components/sections/ProductListing/product-listing.scss
+++ b/src/components/sections/ProductListing/product-listing.scss
@@ -2,7 +2,7 @@
 
 // Check it after apply Skeletons.
 .product-listing {
-  --product-listing-grid-height: 2197px;
+  --product-listing-grid-height: 1164px;
   --product-listing-row-height: var(--space-6);
 
   min-height: var(--product-listing-grid-height);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const ITEMS_PER_PAGE = 24
+export const ITEMS_PER_PAGE = 12


### PR DESCRIPTION
## What's the purpose of this pull request?
24 items per page is just a HUGE number. Reduces this number to 12 to fix the lighthouse warning of too complex HTML

