### PR TITLE
fix: remove unused suspense

### DIFF
--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -1,5 +1,5 @@
 import { useSearch } from '@faststore/sdk'
-import React, { Suspense, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import ProductGrid from 'src/components/product/ProductGrid'
 import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import Sentinel from 'src/sdk/search/Sentinel'
@@ -87,17 +87,7 @@ function GalleryPage({
           />
         </>
       ) : (
-        <Suspense
-          fallback={
-            <div className="product-listing__data-loading">Loading...</div>
-          }
-        >
-          <ProductGrid
-            products={products}
-            page={page}
-            pageSize={itemsPerPage}
-          />
-        </Suspense>
+        <ProductGrid products={products} page={page} pageSize={itemsPerPage} />
       )}
     </>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
ProductGrid was being sync imported, not async, so the suspense wrapper had no effect.


A nice sideeffect is having the lighthouse CI comments back with NO WARNINGS!
<img width="886" alt="image" src="https://user-images.githubusercontent.com/1753396/153066131-480e30f3-a6f4-4a1c-aaad-457be18f96d5.png">
