### PR TITLE
fix: Drop `let` declarator in favor of `useRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder
+- Replaces `let` declarations for `useRef` for better React compatibility
 
 ### Deprecated
 

--- a/src/components/cart/CartSidebar/CartSidebar.tsx
+++ b/src/components/cart/CartSidebar/CartSidebar.tsx
@@ -19,13 +19,13 @@ import EmptyCart from '../EmptyCart'
 
 import './cart-sidebar.scss'
 
-type CB = () => unknown
+type Callback = () => unknown
 
 function CartSidebar() {
   const btnProps = useCheckoutButton()
   const cart = useCart()
   const { displayMinicart, closeMinicart } = useUI()
-  const dismissTransition = useRef<CB | undefined>()
+  const dismissTransition = useRef<Callback | undefined>()
 
   const { items, totalItems, isValidating, subTotal, total } = cart
 
@@ -35,7 +35,7 @@ function CartSidebar() {
     <SlideOver
       isOpen={displayMinicart}
       onDismiss={closeMinicart}
-      onDismissTransition={(cb) => (dismissTransition.current = cb)}
+      onDismissTransition={(callback) => (dismissTransition.current = callback)}
       size="partial"
       direction="rightSide"
       className="cart-sidebar__content"

--- a/src/components/cart/CartSidebar/CartSidebar.tsx
+++ b/src/components/cart/CartSidebar/CartSidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useCart } from 'src/sdk/cart/useCart'
 import { useCheckoutButton } from 'src/sdk/cart/useCheckoutButton'
 import Button from 'src/components/ui/Button'
@@ -19,21 +19,23 @@ import EmptyCart from '../EmptyCart'
 
 import './cart-sidebar.scss'
 
+type CB = () => unknown
+
 function CartSidebar() {
   const btnProps = useCheckoutButton()
   const cart = useCart()
   const { displayMinicart, closeMinicart } = useUI()
+  const dismissTransition = useRef<CB | undefined>()
 
   const { items, totalItems, isValidating, subTotal, total } = cart
 
-  let onDismissTransition: () => unknown
   const isEmpty = items.length === 0
 
   return (
     <SlideOver
       isOpen={displayMinicart}
       onDismiss={closeMinicart}
-      onDismissTransition={(callback) => (onDismissTransition = callback)}
+      onDismissTransition={(cb) => (dismissTransition.current = cb)}
       size="partial"
       direction="rightSide"
       className="cart-sidebar__content"
@@ -57,7 +59,7 @@ function CartSidebar() {
                 classes="cart-sidebar__button"
                 aria-label="Close Cart"
                 icon={<XIcon size={32} />}
-                onClick={() => onDismissTransition()}
+                onClick={() => dismissTransition.current?.()}
               />
             </header>
             <Alert icon={<TruckIcon size={24} />}>
@@ -66,7 +68,7 @@ function CartSidebar() {
           </div>
 
           {isEmpty ? (
-            <EmptyCart onDismiss={() => onDismissTransition()} />
+            <EmptyCart onDismiss={() => dismissTransition.current?.()} />
           ) : (
             <div className="cart-sidebar__items">
               {items.map((item) => (

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react'
+import React, { memo, useRef, useState } from 'react'
 import { Link as LinkGatsby } from 'gatsby'
 import { List as UIList } from '@faststore/ui'
 import CartToggle from 'src/components/cart/CartToggle'
@@ -14,6 +14,8 @@ import { useStoreCollection } from 'src/hooks/useStoreCollection'
 import SearchInput from '../SearchInput'
 
 import './navbar.scss'
+
+type CB = () => unknown
 
 function NavLinks() {
   const links = useStoreCollection()
@@ -36,7 +38,7 @@ function NavLinks() {
 function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
   const { isMobile } = useWindowDimensions()
-  let onDismissTransition: () => unknown
+  const dismissTransition = useRef<CB | undefined>()
 
   return (
     <header className="navbar / grid-content-full">
@@ -68,7 +70,7 @@ function Navbar() {
         <SlideOver
           isOpen={showMenu}
           onDismiss={() => setShowMenu(false)}
-          onDismissTransition={(callback) => (onDismissTransition = callback)}
+          onDismissTransition={(cb) => (dismissTransition.current = cb)}
           size="full"
           direction="leftSide"
           className="navbar__modal-content"
@@ -80,9 +82,7 @@ function Navbar() {
                 aria-label="Go to Faststore home"
                 title="Go to Faststore home"
                 className="navbar__logo"
-                onClick={() => {
-                  onDismissTransition?.()
-                }}
+                onClick={() => dismissTransition.current?.()}
               >
                 <Logo />
               </LinkGatsby>
@@ -91,9 +91,7 @@ function Navbar() {
                 classes="navbar__button"
                 aria-label="Close Menu"
                 icon={<XIcon size={32} />}
-                onClick={() => {
-                  onDismissTransition?.()
-                }}
+                onClick={() => dismissTransition.current?.()}
               />
             </header>
             <div className="navlinks">

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -15,7 +15,7 @@ import SearchInput from '../SearchInput'
 
 import './navbar.scss'
 
-type CB = () => unknown
+type Callback = () => unknown
 
 function NavLinks() {
   const links = useStoreCollection()
@@ -38,7 +38,7 @@ function NavLinks() {
 function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
   const { isMobile } = useWindowDimensions()
-  const dismissTransition = useRef<CB | undefined>()
+  const dismissTransition = useRef<Callback | undefined>()
 
   return (
     <header className="navbar / grid-content-full">
@@ -70,7 +70,9 @@ function Navbar() {
         <SlideOver
           isOpen={showMenu}
           onDismiss={() => setShowMenu(false)}
-          onDismissTransition={(cb) => (dismissTransition.current = cb)}
+          onDismissTransition={(callback) =>
+            (dismissTransition.current = callback)
+          }
           size="full"
           direction="leftSide"
           className="navbar__modal-content"

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -70,9 +70,9 @@ function Navbar() {
         <SlideOver
           isOpen={showMenu}
           onDismiss={() => setShowMenu(false)}
-          onDismissTransition={(callback) =>
-            (dismissTransition.current = callback)
-          }
+          onDismissTransition={(callback) => {
+            dismissTransition.current = callback
+          }}
           size="full"
           direction="leftSide"
           className="navbar__modal-content"

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -41,7 +41,7 @@ type ActiveFacets = {
   accordionIndex: number
 }
 
-type CB = () => unknown
+type Callback = () => unknown
 
 function Filter({
   facets,
@@ -52,7 +52,7 @@ function Filter({
 }: FilterProps) {
   const { isMobile } = useWindowDimensions()
   const { toggleFacets, state: searchState } = useSearch()
-  const dismissTransition = useRef<CB | undefined>()
+  const dismissTransition = useRef<Callback | undefined>()
 
   const [indicesExpanded, setIndicesExpanded] = useState<Set<number>>(
     new Set([])

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useRef } from 'react'
 import { useSearch } from '@faststore/sdk'
 import type {
   IStoreSelectedFacet,
@@ -41,6 +41,8 @@ type ActiveFacets = {
   accordionIndex: number
 }
 
+type CB = () => unknown
+
 function Filter({
   facets,
   onDismiss,
@@ -50,6 +52,7 @@ function Filter({
 }: FilterProps) {
   const { isMobile } = useWindowDimensions()
   const { toggleFacets, state: searchState } = useSearch()
+  const dismissTransition = useRef<CB | undefined>()
 
   const [indicesExpanded, setIndicesExpanded] = useState<Set<number>>(
     new Set([])
@@ -63,7 +66,6 @@ function Filter({
     []
   )
 
-  let onDismissTransition: () => unknown
   const [activeFacets, setActiveFacets] = useState<ActiveFacets[]>([])
   const filteredFacets = facets.filter((facet) => facet.type === 'BOOLEAN')
 
@@ -158,7 +160,7 @@ function Filter({
     toggleFacets(facetsToAdd)
 
     setIndicesExpanded(new Set([]))
-    onDismissTransition?.()
+    dismissTransition.current?.()
   }
 
   return !isMobile ? (
@@ -176,7 +178,7 @@ function Filter({
     <SlideOver
       isOpen={isOpen}
       onDismiss={onDismiss}
-      onDismissTransition={(callback) => (onDismissTransition = callback)}
+      onDismissTransition={(callback) => (dismissTransition.current = callback)}
       size="partial"
       direction="rightSide"
       className="filter-modal__content"
@@ -191,7 +193,7 @@ function Filter({
             icon={<XIcon size={32} />}
             onClick={() => {
               setSelectedFacets(searchState.selectedFacets)
-              onDismissTransition?.()
+              dismissTransition.current?.()
             }}
           />
         </header>


### PR DESCRIPTION
## What's the purpose of this pull request?
Some components were using `let` variable declarator to create a variable to store mutating values. Turns out this is not guarantee to work 100% and is a react anti pattern. For this job of storing mutating values, use https://reactjs.org/docs/hooks-reference.html#useref

## How does it work?
This PR moves all `let` declarations to use `useRef` instead

## How to test it?
Everything should be working as before

## Checklist
- [x] CHANGELOG entry added
