### PR TITLE
fix: Use Gatsby-Link on Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `GatsbyLink` to `Link` ui component.
 
 ### Changed
 

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -40,7 +40,7 @@ function Footer() {
           <UIList variant="unordered">
             <li>
               <Link
-                href="https://www.facebook.com/"
+                to="https://www.facebook.com/"
                 title="Facebook"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -50,7 +50,7 @@ function Footer() {
             </li>
             <li>
               <Link
-                href="https://www.instagram.com/"
+                to="https://www.instagram.com/"
                 title="Instagram"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -60,7 +60,7 @@ function Footer() {
             </li>
             <li>
               <Link
-                href="https://www.pinterest.com/"
+                to="https://www.pinterest.com/"
                 title="Pinterest"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -70,7 +70,7 @@ function Footer() {
             </li>
             <li>
               <Link
-                href="https://twitter.com/"
+                to="https://twitter.com/"
                 title="Twitter"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -40,7 +40,8 @@ function Footer() {
           <UIList variant="unordered">
             <li>
               <Link
-                to="https://www.facebook.com/"
+                as="a"
+                href="https://www.facebook.com/"
                 title="Facebook"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -50,7 +51,8 @@ function Footer() {
             </li>
             <li>
               <Link
-                to="https://www.instagram.com/"
+                as="a"
+                href="https://www.instagram.com/"
                 title="Instagram"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -60,7 +62,8 @@ function Footer() {
             </li>
             <li>
               <Link
-                to="https://www.pinterest.com/"
+                as="a"
+                href="https://www.pinterest.com/"
                 title="Pinterest"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -70,7 +73,8 @@ function Footer() {
             </li>
             <li>
               <Link
-                to="https://twitter.com/"
+                as="a"
+                href="https://twitter.com/"
                 title="Twitter"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react'
 import { List as UIList } from '@faststore/ui'
 import useWindowDimensions from 'src/hooks/useWindowDimensions'
-
-import Link from '../../ui/Link'
-import Accordion, { AccordionItem } from '../../ui/Accordion'
+import Link from 'src/components/ui/Link'
+import Accordion, { AccordionItem } from 'src/components/ui/Accordion'
 
 const links = [
   {
@@ -98,7 +97,7 @@ function LinksList({ items }: LinksListProps) {
     <UIList>
       {items.map((item) => (
         <li key={item.name}>
-          <Link variant="footer" href={item.href}>
+          <Link variant="footer" to={item.href}>
             {item.name}
           </Link>
         </li>

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -25,7 +25,7 @@ function NavLinks() {
       <UIList>
         {links.map(({ node: link }) => (
           <li key={link.seo.title}>
-            <Link variant="display" href={`/${link.slug}`}>
+            <Link variant="display" to={`/${link.slug}`}>
               {link.seo.title}
             </Link>
           </li>

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+import type { AnchorHTMLAttributes } from 'react'
 import React, { memo, useRef, useState } from 'react'
 import { Link as LinkGatsby } from 'gatsby'
 import { List as UIList } from '@faststore/ui'
@@ -17,7 +18,11 @@ import './navbar.scss'
 
 type Callback = () => unknown
 
-function NavLinks() {
+interface NavLinksProps {
+  onClickLink?: AnchorHTMLAttributes<HTMLAnchorElement>['onClick']
+}
+
+function NavLinks({ onClickLink }: NavLinksProps) {
   const links = useStoreCollection()
 
   return (
@@ -25,7 +30,7 @@ function NavLinks() {
       <UIList>
         {links.map(({ node: link }) => (
           <li key={link.seo.title}>
-            <Link variant="display" to={`/${link.slug}`}>
+            <Link variant="display" to={`/${link.slug}`} onClick={onClickLink}>
               {link.seo.title}
             </Link>
           </li>
@@ -39,6 +44,7 @@ function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
   const { isMobile } = useWindowDimensions()
   const dismissTransition = useRef<Callback | undefined>()
+  const handleCloseSlideOver = () => setShowMenu(false)
 
   return (
     <header className="navbar / grid-content-full">
@@ -69,7 +75,7 @@ function Navbar() {
       {isMobile && (
         <SlideOver
           isOpen={showMenu}
-          onDismiss={() => setShowMenu(false)}
+          onDismiss={handleCloseSlideOver}
           onDismissTransition={(callback) => {
             dismissTransition.current = callback
           }}
@@ -97,7 +103,7 @@ function Navbar() {
               />
             </header>
             <div className="navlinks">
-              <NavLinks />
+              <NavLinks onClickLink={handleCloseSlideOver} />
               <div className="navlinks__signin">
                 <SignInLink />
               </div>

--- a/src/components/sections/BannerText/BannerText.tsx
+++ b/src/components/sections/BannerText/BannerText.tsx
@@ -41,7 +41,7 @@ function BannerText({
           <p>{caption}</p>
         </div>
         <BannerLink>
-          <LinkButton href={actionPath} inverse>
+          <LinkButton to={actionPath} inverse>
             {actionLabel}
           </LinkButton>
         </BannerLink>

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -49,7 +49,7 @@ const Hero = ({
             <p className="text-body-big">{subtitle}</p>
             {!!link && (
               <HeroLink>
-                <LinkButton href={link} inverse>
+                <LinkButton to={link} inverse>
                   {linkText} <ArrowRightIcon size={24} />
                 </LinkButton>
               </HeroLink>

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -82,7 +82,7 @@ function ProductGallery({ title, slug }: Props) {
                 e.preventDefault()
                 addPrevPage()
               }}
-              href={prev.link}
+              to={prev.link}
               rel="prev"
               variant="secondary"
               iconPosition="left"
@@ -137,7 +137,7 @@ function ProductGallery({ title, slug }: Props) {
                 e.preventDefault()
                 addNextPage()
               }}
-              href={next.link}
+              to={next.link}
               rel="next"
               variant="secondary"
             >

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -24,7 +24,7 @@ function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
 
   return (
     <UIBreadcrumb divider="">
-      <Link aria-label="home" href="/">
+      <Link aria-label="home" to="/">
         <HouseIcon size={18} weight="bold" />
       </Link>
 
@@ -32,7 +32,7 @@ function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
         return breadcrumbList.length === index + 1 ? (
           <span key={String(index)}>{name}</span>
         ) : (
-          <Link href={buildUrl(item)} key={String(index)}>
+          <Link to={buildUrl(item)} key={String(index)}>
             {name}
           </Link>
         )

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -16,12 +16,6 @@ export interface BreadcrumbProps extends UIBreadcrumbProps {
 }
 
 function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
-  const buildUrl = (url: string) => {
-    const parsedUrl = url.split('/')
-
-    return `/${parsedUrl[parsedUrl.length - 1]}`
-  }
-
   return (
     <UIBreadcrumb divider="">
       <Link aria-label="home" to="/">
@@ -32,7 +26,7 @@ function Breadcrumb({ breadcrumbList }: BreadcrumbProps) {
         return breadcrumbList.length === index + 1 ? (
           <span key={String(index)}>{name}</span>
         ) : (
-          <Link to={buildUrl(item)} key={String(index)}>
+          <Link to={item} key={String(index)}>
             {name}
           </Link>
         )

--- a/src/components/ui/Button/LinkButton.tsx
+++ b/src/components/ui/Button/LinkButton.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import type { LinkProps } from '@faststore/ui'
 import { Icon as UIIcon, Link as UILink } from '@faststore/ui'
 import type { FocusEvent } from 'react'
+import { Link as GatsbyLink } from 'gatsby'
 
 import type { UIButtonProps } from './Button'
 
@@ -10,7 +11,7 @@ import './buttons.scss'
 type Props = {
   disabled?: boolean
 } & UIButtonProps &
-  LinkProps<'a'>
+  LinkProps<typeof GatsbyLink>
 
 function LinkButton({
   variant = 'primary',
@@ -26,7 +27,8 @@ function LinkButton({
 
   return (
     <UILink
-      ref={linkRef}
+      as={GatsbyLink}
+      innerRef={linkRef}
       data-store-button
       className={`link-button ${className}`}
       data-button-variant={variant}

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,3 +1,4 @@
+import type { ElementType } from 'react'
 import React from 'react'
 import { Link as UILink } from '@faststore/ui'
 import type { LinkProps } from '@faststore/ui'
@@ -7,17 +8,23 @@ import './link.scss'
 
 type Variant = 'default' | 'display' | 'inline' | 'footer'
 
-type Props = LinkProps<typeof GatsbyLink> & {
+type Props<T extends ElementType = typeof GatsbyLink> = LinkProps<T> & {
   variant?: Variant
   inverse?: boolean
 }
 
-function Link({ variant = 'default', inverse, ...props }: Props) {
+function Link<T extends ElementType = typeof GatsbyLink>({
+  variant = 'default',
+  inverse,
+  to,
+  ...props
+}: Props<T>) {
   return (
     <UILink
       as={GatsbyLink}
       data-link-variant={variant}
       data-link-inverse={inverse}
+      to={to}
       {...props}
     />
   )

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Link as UILink } from '@faststore/ui'
 import type { LinkProps } from '@faststore/ui'
+import { Link as GatsbyLink } from 'gatsby'
 
 import './link.scss'
 
 type Variant = 'default' | 'display' | 'inline' | 'footer'
 
-type Props = LinkProps<'a'> & {
+type Props = LinkProps<typeof GatsbyLink> & {
   variant?: Variant
   inverse?: boolean
 }
@@ -14,6 +15,7 @@ type Props = LinkProps<'a'> & {
 function Link({ variant = 'default', inverse, ...props }: Props) {
   return (
     <UILink
+      as={GatsbyLink}
       data-link-variant={variant}
       data-link-inverse={inverse}
       {...props}

--- a/src/components/ui/SignInLink/SignInLink.tsx
+++ b/src/components/ui/SignInLink/SignInLink.tsx
@@ -7,7 +7,7 @@ const SignInLink: React.FC = () => {
   return (
     <LinkButton
       data-button-signin-link
-      href="/"
+      to="/"
       className="title-sub-subsection signin-link"
       variant="tertiary"
     >


### PR DESCRIPTION
## What's the purpose of this pull request?
Use GatsbyLink component to do client-side navigation.

## How does it work?
Pass to  `GatsbyLink` component to `as` prop from @faststore/ui `Link`.

## How to test it?
Click on store links and check if the navigation is client-side.

## References

## Checklist
- [x] CHANGELOG entry added
