### PR TITLE
Fix: Filter button only on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - React tree re-rendering
 - Footer rendering pipeline
+- Filter Button specificity on desktop
 
 ### Security
 

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -69,7 +69,7 @@
     min-height: initial;
     padding: 0;
 
-    .button {
+    .button[data-store-button] {
       display: none;
     }
   }


### PR DESCRIPTION
## What's the purpose of this pull request?

Sometimes we are having some CSS specificity issues on the Filter button that should be shown only on the mobile screen. So this PR increases the specificity of this element from (0,2,0) to (0,3,0).

|Before|After|
|-|-|
|<img width="1075" alt="Screen Shot 2022-02-17 at 13 44 48" src="https://user-images.githubusercontent.com/11325562/154529269-2a286088-0dba-4f60-a4d6-5856f052c180.png">|<img width="1066" alt="Screen Shot 2022-02-17 at 13 44 37" src="https://user-images.githubusercontent.com/11325562/154529302-f0954080-8738-4bb9-bb7c-627e902b909f.png">|
|<img width="1303" alt="Screen Shot 2022-02-17 at 13 50 39" src="https://user-images.githubusercontent.com/11325562/154530731-3bf67fbb-cb32-4a8b-9d16-bf93040bda7f.png">|<img width="1308" alt="Screen Shot 2022-02-17 at 13 55 38" src="https://user-images.githubusercontent.com/11325562/154531323-d59da72a-f1a2-4462-9de2-0a47429b16f2.png">|


## How to test it?

We shouldn't see the Filter button while using desktop breakpoint.
 https://preview-346--base.preview.vtex.app/office/ 

## References
https://polypane.app/css-specificity-calculator/#selector=.product-listing__sort%20.button

## Checklist

- [x] CHANGELOG entry added
