### PR TITLE
feat: Add expanded search state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BreadcrumbWrapper` from components/ui folder to `Breadcrumb` at components/sections
 - Replace relative stylesheets imports with absolute path
 - Moves some `Filter` component logic to the API
+-  Implements the expanded mode of `Searchbar` in mobile devices.
 
 ### Deprecated
 - useWindowDimensions hook

--- a/cypress/integration/analytics.test.js
+++ b/cypress/integration/analytics.test.js
@@ -192,13 +192,17 @@ describe('search event', () => {
     cy.visit(pages.home, options)
     cy.waitForHydration()
 
-    cy.getById('store-search-input').within(() => {
-      cy.getById('store-input').click().type('shirt')
-      cy.getById('store-button')
-        .click()
-        .then(() => {
-          dataLayerHasEvent('search')
-        })
-    })
+    cy.getById('store-input-mobile-button').click({ force: true })
+
+    cy.getById('store-input-mobile')
+      .click()
+      .type('shirt')
+      .within(() => {
+        cy.getById('store-button')
+          .click()
+          .then(() => {
+            dataLayerHasEvent('search')
+          })
+      })
   })
 })

--- a/cypress/integration/search.test.js
+++ b/cypress/integration/search.test.js
@@ -21,11 +21,14 @@ describe('Search input', () => {
       cy.visit(pages.home, options)
       cy.waitForHydration()
 
-      cy.get('form[data-store-search-input]').within(() => {
-        cy.getById('store-input').click().type(term)
+      cy.getById('store-input-mobile-button').click({ force: true })
 
-        cy.getById('store-button').click()
-      })
+      cy.getById('store-input-mobile')
+        .click()
+        .type(term)
+        .within(() => {
+          cy.getById('store-button').click()
+        })
 
       cy.location('search').should((loc) => {
         expect(loc).to.include(`q=${term}`)

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -84,6 +84,8 @@ function Navbar() {
             )}
             <SearchInput
               placeholder=""
+              testId="store-input-mobile"
+              buttonTestId="store-input-mobile-button"
               onMagnifierClick={() => setSearchExpanded(true)}
             />
             <CartToggle />

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+import type { SearchInputRef } from '@faststore/ui'
 import { List as UIList } from '@faststore/ui'
 import { Link as LinkGatsby } from 'gatsby'
 import React, { useRef, useState } from 'react'
@@ -6,7 +7,11 @@ import CartToggle from 'src/components/cart/CartToggle'
 import IconButton from 'src/components/ui/IconButton'
 import Link from 'src/components/ui/Link'
 import Logo from 'src/components/ui/Logo'
-import { CaretLeft, List as ListIcon, X as XIcon } from 'phosphor-react'
+import {
+  CaretLeft as CaretLeftIcon,
+  List as ListIcon,
+  X as XIcon,
+} from 'phosphor-react'
 import SignInLink from 'src/components/ui/SignInLink'
 import SlideOver from 'src/components/ui/SlideOver'
 import { useStoreCollection } from 'src/hooks/useAllCollections'
@@ -44,8 +49,14 @@ function NavLinks({ onClickLink }: NavLinksProps) {
 function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
   const [searchExpanded, setSearchExpanded] = useState(false)
+  const searchMobileRef = useRef<SearchInputRef>(null)
   const dismissTransition = useRef<Callback | undefined>()
   const handleCloseSlideOver = () => setShowMenu(false)
+
+  const handlerExpandSearch = () => {
+    setSearchExpanded(true)
+    searchMobileRef.current?.inputRef?.focus()
+  }
 
   return (
     <header className="navbar / grid-content-full">
@@ -78,15 +89,16 @@ function Navbar() {
               <IconButton
                 classes="navbar__collapse"
                 aria-label="Collapse search bar"
-                icon={<CaretLeft size={32} />}
+                icon={<CaretLeftIcon size={32} />}
                 onClick={() => setSearchExpanded(false)}
               />
             )}
             <SearchInput
               placeholder=""
+              ref={searchMobileRef}
               testId="store-input-mobile"
               buttonTestId="store-input-mobile-button"
-              onSearchClick={() => setSearchExpanded(true)}
+              onSearchClick={handlerExpandSearch}
             />
             <SignInLink />
             <CartToggle />

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,12 +1,12 @@
 import { List as UIList } from '@faststore/ui'
 import { Link as LinkGatsby } from 'gatsby'
-import { List as ListIcon, X as XIcon } from 'phosphor-react'
 import React, { useRef, useState } from 'react'
 import type { AnchorHTMLAttributes } from 'react'
 import CartToggle from 'src/components/cart/CartToggle'
 import IconButton from 'src/components/ui/IconButton'
 import Link from 'src/components/ui/Link'
 import Logo from 'src/components/ui/Logo'
+import { CaretLeft, List as ListIcon, X as XIcon } from 'phosphor-react'
 import SignInLink from 'src/components/ui/SignInLink'
 import SlideOver from 'src/components/ui/SlideOver'
 import { useStoreCollection } from 'src/hooks/useAllCollections'
@@ -43,6 +43,7 @@ function NavLinks({ onClickLink }: NavLinksProps) {
 
 function Navbar() {
   const [showMenu, setShowMenu] = useState(false)
+  const [searchExpanded, setSearchExpanded] = useState(false)
   const dismissTransition = useRef<Callback | undefined>()
   const handleCloseSlideOver = () => setShowMenu(false)
 
@@ -50,23 +51,41 @@ function Navbar() {
     <header className="navbar / grid-content-full">
       <div className="navbar__header / grid-content">
         <section className="navbar__row">
-          <IconButton
-            classes="navbar__menu"
-            aria-label="Open Menu"
-            icon={<ListIcon size={32} />}
-            onClick={() => setShowMenu(true)}
-          />
-          <LinkGatsby
-            to="/"
-            aria-label="Go to Faststore home"
-            title="Go to Faststore home"
-            className="navbar__logo"
-          >
-            <Logo />
-          </LinkGatsby>
+          {!searchExpanded && (
+            <>
+              <IconButton
+                classes="navbar__menu"
+                aria-label="Open Menu"
+                icon={<ListIcon size={32} />}
+                onClick={() => setShowMenu(true)}
+              />
+              <LinkGatsby
+                to="/"
+                aria-label="Go to Faststore home"
+                title="Go to Faststore home"
+                className="navbar__logo"
+              >
+                <Logo />
+              </LinkGatsby>
+            </>
+          )}
           <SearchInput />
-          <div className="navbar__buttons">
-            <SignInLink />
+          <div
+            className="navbar__buttons"
+            data-store-search-expanded={searchExpanded}
+          >
+            {searchExpanded && (
+              <IconButton
+                classes="retract__button"
+                aria-label="Retract Searchbar"
+                icon={<CaretLeft size={32} />}
+                onClick={() => setSearchExpanded(false)}
+              />
+            )}
+            <SearchInput
+              placeholder=""
+              onMagnifierClick={() => setSearchExpanded(true)}
+            />
             <CartToggle />
           </div>
         </section>

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -76,8 +76,8 @@ function Navbar() {
           >
             {searchExpanded && (
               <IconButton
-                classes="retract__button"
-                aria-label="Retract Searchbar"
+                classes="navbar__collapse"
+                aria-label="Collapse search bar"
                 icon={<CaretLeft size={32} />}
                 onClick={() => setSearchExpanded(false)}
               />
@@ -86,8 +86,9 @@ function Navbar() {
               placeholder=""
               testId="store-input-mobile"
               buttonTestId="store-input-mobile-button"
-              onMagnifierClick={() => setSearchExpanded(true)}
+              onSearchClick={() => setSearchExpanded(true)}
             />
+            <SignInLink />
             <CartToggle />
           </div>
         </section>

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -81,7 +81,7 @@
       }
 
       [data-store-icon] {
-        margin-right: -1.25rem;
+        margin-right: 0;
         line-height: 0;
 
         svg {
@@ -94,6 +94,10 @@
 
   &[data-store-search-expanded="true"] {
     width: 100%;
+
+    .retract__button {
+      margin-left: calc(var(--space-4) * -1);
+    }
 
     [data-store-search-input] {
       flex: 1 1;

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -43,8 +43,8 @@
   align-items: center;
   justify-content: flex-end;
 
-  .retract__button {
-    margin-left: calc(var(--space-3) * -1);
+  .navbar__collapse {
+    margin-left: calc(-1 * var(--space-3));
   }
 
   .signin-link[data-button-signin-link] {
@@ -95,16 +95,12 @@
   &[data-store-search-expanded="true"] {
     width: 100%;
 
-    .retract__button {
-      margin-left: calc(var(--space-4) * -1);
-    }
-
     [data-store-search-input] {
       flex: 1 1;
       margin-right: 0.625rem;
 
       [data-store-input] {
-        width: 100%;
+        width: calc(100% - var(--space-7));
       }
 
       [data-store-icon] {

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -8,6 +8,10 @@
   [data-store-search-input] {
     flex: 1 0 100%;
     order: 2;
+
+    @include media("<notebook") {
+      display: none;
+    }
   }
 }
 
@@ -39,6 +43,10 @@
   align-items: center;
   justify-content: flex-end;
 
+  .retract__button {
+    margin-left: calc(var(--space-3) * -1);
+  }
+
   .signin-link[data-button-signin-link] {
     display: none;
   }
@@ -50,11 +58,67 @@
       display: inline-flex;
     }
   }
+
+  [data-store-search-input] {
+    display: none;
+    transition: flex 0.3s ease-in;
+
+    @include media("<notebook") {
+      display: inline-flex;
+      flex: 0;
+      order: 0;
+      width: min-content;
+
+      [data-store-input] {
+        width: 0;
+        padding: 0;
+        border-width: 0;
+
+        &:hover, &:focus, &:focus-visible &:hover:focus-visible {
+          border-width: 0;
+          box-shadow: 0 0;
+        }
+      }
+
+      [data-store-icon] {
+        margin-right: -1.25rem;
+        line-height: 0;
+
+        svg {
+          width: var(--space-5);
+          height: var(--space-5);
+        }
+      }
+    }
+  }
+
+  &[data-store-search-expanded="true"] {
+    width: 100%;
+
+    [data-store-search-input] {
+      flex: 1 1;
+      margin-right: 0.625rem;
+
+      [data-store-input] {
+        width: 100%;
+      }
+
+      [data-store-icon] {
+        margin-right: 0;
+      }
+    }
+
+    .cart-toggle {
+      margin-right: -4.063rem;
+      transition: margin 0.3s ease-in;
+    }
+  }
 }
 
 .navbar__header {
   padding-top: var(--space-1);
   padding-bottom: var(--space-2);
+  overflow: hidden;
 
   @include media(">=notebook") {
     padding-top: var(--space-1);

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -14,6 +14,7 @@ import './search-input.scss'
 
 declare type SearchInputProps = {
   onMagnifierClick?: () => void
+  buttonTestId?: string
 } & Omit<UISearchInputProps, 'onSubmit'>
 
 const doSearch = async (term: string) => {
@@ -32,10 +33,19 @@ const doSearch = async (term: string) => {
   navigate(`${pathname}${search}`)
 }
 
-function SearchInput({ onMagnifierClick, ...props }: SearchInputProps) {
+function SearchInput({
+  onMagnifierClick,
+  buttonTestId = 'store-search-button',
+  ...props
+}: SearchInputProps) {
   return (
     <UISearchInput
-      icon={<MagnifyingGlassIcon onClick={onMagnifierClick} />}
+      icon={
+        <MagnifyingGlassIcon
+          onClick={onMagnifierClick}
+          data-testid={buttonTestId}
+        />
+      }
       placeholder="Search everything at the store"
       onSubmit={doSearch}
       {...props}

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -12,7 +12,9 @@ import { MagnifyingGlass as MagnifyingGlassIcon } from 'phosphor-react'
 
 import './search-input.scss'
 
-declare type SearchInputProps = Omit<UISearchInputProps, 'onSubmit'>
+declare type SearchInputProps = {
+  onMagnifierClick?: () => void
+} & Omit<UISearchInputProps, 'onSubmit'>
 
 const doSearch = async (term: string) => {
   const { pathname, search } = formatSearchState(
@@ -30,10 +32,10 @@ const doSearch = async (term: string) => {
   navigate(`${pathname}${search}`)
 }
 
-function SearchInput(props: SearchInputProps) {
+function SearchInput({ onMagnifierClick, ...props }: SearchInputProps) {
   return (
     <UISearchInput
-      icon={<MagnifyingGlassIcon />}
+      icon={<MagnifyingGlassIcon onClick={onMagnifierClick} />}
       placeholder="Search everything at the store"
       onSubmit={doSearch}
       {...props}

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -7,7 +7,10 @@ import {
 import { SearchInput as UISearchInput } from '@faststore/ui'
 import { navigate } from 'gatsby'
 import React from 'react'
-import type { SearchInputProps as UISearchInputProps } from '@faststore/ui'
+import type {
+  SearchInputProps as UISearchInputProps,
+  SearchInputRef,
+} from '@faststore/ui'
 import { MagnifyingGlass as MagnifyingGlassIcon } from 'phosphor-react'
 
 import './search-input.scss'
@@ -33,24 +36,26 @@ const doSearch = async (term: string) => {
   navigate(`${pathname}${search}`)
 }
 
-function SearchInput({
-  onSearchClick,
-  buttonTestId = 'store-search-button',
-  ...props
-}: SearchInputProps) {
-  return (
-    <UISearchInput
-      icon={
-        <MagnifyingGlassIcon
-          onClick={onSearchClick}
-          data-testid={buttonTestId}
-        />
-      }
-      placeholder="Search everything at the store"
-      onSubmit={doSearch}
-      {...props}
-    />
-  )
-}
+const SearchInput = React.forwardRef<SearchInputRef, SearchInputProps>(
+  function SearchInput(
+    { onSearchClick, buttonTestId = 'store-search-button', ...props },
+    ref
+  ) {
+    return (
+      <UISearchInput
+        ref={ref}
+        icon={
+          <MagnifyingGlassIcon
+            onClick={onSearchClick}
+            data-testid={buttonTestId}
+          />
+        }
+        placeholder="Search everything at the store"
+        onSubmit={doSearch}
+        {...props}
+      />
+    )
+  }
+)
 
 export default SearchInput

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -13,7 +13,7 @@ import { MagnifyingGlass as MagnifyingGlassIcon } from 'phosphor-react'
 import './search-input.scss'
 
 declare type SearchInputProps = {
-  onMagnifierClick?: () => void
+  onSearchClick?: () => void
   buttonTestId?: string
 } & Omit<UISearchInputProps, 'onSubmit'>
 
@@ -34,7 +34,7 @@ const doSearch = async (term: string) => {
 }
 
 function SearchInput({
-  onMagnifierClick,
+  onSearchClick,
   buttonTestId = 'store-search-button',
   ...props
 }: SearchInputProps) {
@@ -42,7 +42,7 @@ function SearchInput({
     <UISearchInput
       icon={
         <MagnifyingGlassIcon
-          onClick={onMagnifierClick}
+          onClick={onSearchClick}
           data-testid={buttonTestId}
         />
       }


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?

This PR Implements the expanded mode of `Searchbar` in mobile devices.

## How does it work?
In mobile devices, when magnifier Icon is clicked the Searchbar should expand with animation, and when Arrow Left Icon is clicked the searchbar should retract.

![animation](https://user-images.githubusercontent.com/51174217/154742622-465c3ea8-2622-47db-ad6a-eeeeac372be4.gif)

## How to test it?

For add this behaviour, the searchbar test was modified

## Checklist



- [x] CHANGELOG entry added
- [x] Add the expanded state
- [x] Add Animation when Searchbar to expand
- [x] Retract Searchbar when Back Icon is clicked
- [x] Adjust Searchbar tests.
