### PR TITLE
chore: fix Hero Image sizes and css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moves some `Filter` component logic to the API
 - Implements the expanded mode of `Searchbar` in mobile devices.
 - Updates Lighthouse and Cypress URL with valid product links
+- `Hero` image responsive sizes for mobile and desktop.
 
 ### Deprecated
 

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -69,8 +69,13 @@ const Hero = ({
           options={{
             fitIn: true,
           }}
+          // reset gatsby image default style
+          style={{
+            overflow: undefined,
+            position: undefined,
+          }}
           // for mobile load 100vw image, for desktop load half img
-          sizes="(max-width: 768px) 100vw, 50vw"
+          sizes="(max-width: 768px) 100vw, 53vw"
         />
       </HeroImage>
     </UIHero>

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -69,6 +69,8 @@ const Hero = ({
           options={{
             fitIn: true,
           }}
+          // for mobile load 100vw image, for desktop load half img
+          sizes="(max-width: 768px) 100vw, 50vw"
         />
       </HeroImage>
     </UIHero>

--- a/src/components/ui/Hero/hero.scss
+++ b/src/components/ui/Hero/hero.scss
@@ -59,6 +59,11 @@
   }
 
   [data-hero-image] {
+    // override 50% padding top from component
+    [aria-hidden][style]:first-child {
+      padding-top: 100% !important; /* stylelint-disable-line declaration-no-important */
+    }
+
     [data-gatsby-image-wrapper] {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the image HTML sizes property, by doing this you let the browser choose a better image to fetch.
Nowadays the Image component uses the gatsby-image-plugin that sets a default `100vw` for sizes. For small screens with size less than 768px, must fetch images with the 100vw size or higher, but for screens higher than 768px the Hero component renders a image with the half of screen width.

Because of it on devices with bigger screens was fetching an image with high resolution without necessity.
**Before**:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15680320/155595950-8b6d18ae-50e4-43f3-ba1c-232a209afffa.png">

**After** 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15680320/155596029-2a05a6ee-f1a5-4591-b8ee-8756c077b9e6.png">

⚠️ Pay attention on images sizes and links that has resolution of image.

Also, remove unnecessary padding that the gatsby-image-plugin set.

## How does it work?
Set 100vw for screens with max-width = 768px and 50vw for higher screen width.

## How to test it?
Open the preview and see the Hero image size versus the same image on production https://base.vtex.app

## References
https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images

## Checklist
TBD
- [] CHANGELOG entry added
