### PR TITLE
feat: Search Suggestions component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EmptyState` component.
 - `EmptyState` at the `ProductGallery` section.
 - `IconSVG` component to load SVG Icons.
+- `Suggestions` component.
 
 ### Changed
 - Moved all icons to use Icon component

--- a/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
+++ b/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
@@ -32,16 +32,14 @@ const imgOptions = {
 
 function SuggestionProductCard({
   // TODO: Add Props interface and define `product` type
-  product = PRODUCTS,
+  product = PRODUCTS[0],
 }) {
-  const [
-    {
-      name,
-      listPrice,
-      price,
-      image: [img],
-    },
-  ] = product
+  const {
+    name,
+    listPrice,
+    price,
+    image: [img],
+  } = product
 
   return (
     <Card

--- a/src/components/search/SuggestionProductCard/suggestion-product-card.scss
+++ b/src/components/search/SuggestionProductCard/suggestion-product-card.scss
@@ -1,7 +1,7 @@
 @import "src/styles/scaffold";
 
 .suggestion-product-card {
-  padding: var(--space-1) var(--space-3);
+  padding: var(--space-1) 0;
 
   [data-card-content] {
     display: grid;

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -57,6 +57,30 @@ function formatSearchTerm(
   return searchTerm.toLowerCase()
 }
 
+function handleSuggestions(suggestion: string, searchTerm: string) {
+  const suggestionSubstring = suggestion
+    .toLowerCase()
+    .split(searchTerm.toLowerCase())
+
+  return (
+    <p>
+      {suggestionSubstring.map((substring, indexSubstring) => (
+        <>
+          {substring.length > 0 && (
+            <b className="suggestions__item-bold">
+              {indexSubstring === 0
+                ? substring.charAt(0).toUpperCase() + substring.slice(1)
+                : substring}
+            </b>
+          )}
+          {indexSubstring !== suggestionSubstring.length - 1 &&
+            formatSearchTerm(indexSubstring, searchTerm, suggestion)}
+        </>
+      ))}
+    </p>
+  )
+}
+
 export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
@@ -77,30 +101,6 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
       SUGGESTED_PRODUCTS.length > 0
         ? SUGGESTIONS.slice(0, MAX_SUGGESTIONS_WITH_PRODUCTS)
         : SUGGESTIONS.slice(0, MAX_SUGGESTIONS)
-
-    const handleSuggestions = (suggestion: string, searchTerm: string) => {
-      const suggestionSubstring = suggestion
-        .toLowerCase()
-        .split(searchTerm.toLowerCase())
-
-      return (
-        <p>
-          {suggestionSubstring.map((substring, indexSubstring) => (
-            <>
-              {substring.length > 0 && (
-                <b className="suggestions__item-bold">
-                  {indexSubstring === 0
-                    ? substring.charAt(0).toUpperCase() + substring.slice(1)
-                    : substring}
-                </b>
-              )}
-              {indexSubstring !== suggestionSubstring.length - 1 &&
-                formatSearchTerm(indexSubstring, searchTerm, suggestion)}
-            </>
-          ))}
-        </p>
-      )
-    }
 
     return (
       <section

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -112,11 +112,8 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
         {suggestions.length > 0 && (
           <UIList data-suggestions-list className="suggestions__section">
             {suggestions?.map((suggestion, index) => (
-              <li key={index}>
-                <Button
-                  onClick={() => null}
-                  className="suggestions__suggestion"
-                >
+              <li key={index} className="suggestions__item">
+                <Button onClick={() => null}>
                   {handleSuggestions(suggestion, term)}
                 </Button>
               </li>
@@ -130,7 +127,7 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
             <UIList>
               {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS).map(
                 (product, index) => (
-                  <li key={index}>
+                  <li key={index} className="suggestions__item">
                     <SuggestionProductCard product={product} />
                   </li>
                 )

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -1,0 +1,108 @@
+import type { HTMLAttributes } from 'react'
+import React, { forwardRef } from 'react'
+import { List as UIList } from '@faststore/ui'
+import Link from 'src/components/ui/Link'
+
+import SuggestionProductCard from '../SuggestionProductCard'
+
+import './suggestions.scss'
+
+const MAX_SUGGESTED_PRODUCTS = 4
+const SUGGESTED_PRODUCTS = [
+  {
+    name: 'Ergonomic Wooden Bacon',
+    listPrice: 72.06,
+    price: 46.26,
+    image: [
+      {
+        alternateName: 'rerum',
+        url: 'http://storeframework.vtexassets.com/arquivos/ids/167285/ut.jpg?v=637753017045600000',
+      },
+    ],
+  },
+  {
+    name: 'Handcrafted Rubber Sausages',
+    listPrice: 59.57,
+    price: 32.83,
+    image: [
+      {
+        alternateName: 'ea',
+        url: 'http://storeframework.vtexassets.com/arquivos/ids/155949/voluptas.jpg?v=637752878341070000',
+      },
+    ],
+  },
+]
+
+const SEARCH_SUGGESTIONS = [
+  'Sony MX',
+  'Sony MV-100 Headphone',
+  'Sony M2000 Earbuds',
+]
+
+export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
+   */
+  testId?: string
+  /**
+   * Search term
+   */
+  term?: string
+}
+
+const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
+  function Suggestions(
+    { testId = 'suggestions', term = 'ny', ...otherProps },
+    ref
+  ) {
+    const boldTerm = (suggestion: string, _term: string) => {
+      const suggestionChars = suggestion.split(_term)
+
+      return (
+        <p>
+          {suggestionChars.map((char, index) => (
+            <>
+              {char}
+              {index !== suggestionChars.length - 1 && (
+                <b className="suggestions__bold-term">{_term}</b>
+              )}
+            </>
+          ))}
+        </p>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        data-store-suggestions
+        className="suggestions"
+        {...otherProps}
+      >
+        <UIList>
+          {SEARCH_SUGGESTIONS.map((suggestion, index) => (
+            <Link key={index} to="/">
+              {boldTerm(suggestion, term)}
+            </Link>
+          ))}
+        </UIList>
+
+        <div data-suggestions-suggested-products>
+          <p className="suggestions__suggested-products-title">
+            Suggested Products
+          </p>
+          <UIList>
+            {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS + 1).map(
+              (product, index) => (
+                <SuggestionProductCard key={index} product={product} />
+              )
+            )}
+          </UIList>
+        </div>
+      </div>
+    )
+  }
+)
+
+export default Suggestions

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -1,12 +1,13 @@
 import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 import { List as UIList } from '@faststore/ui'
-import Link from 'src/components/ui/Link'
+import Button from 'src/components/ui/Button'
 
 import SuggestionProductCard from '../SuggestionProductCard'
 
 import './suggestions.scss'
 
+const MAX_SUGGESTIONS = 5
 const MAX_SUGGESTED_PRODUCTS = 4
 const SUGGESTED_PRODUCTS = [
   {
@@ -33,11 +34,7 @@ const SUGGESTED_PRODUCTS = [
   },
 ]
 
-const SEARCH_SUGGESTIONS = [
-  'Sony MX',
-  'Sony MV-100 Headphone',
-  'Sony M2000 Earbuds',
-]
+const SUGGESTIONS = ['Sony MX', 'Sony MV-100 Headphone', 'Sony M2000 Earbuds']
 
 export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -55,52 +52,80 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
     { testId = 'suggestions', term = '', ...otherProps },
     ref
   ) {
-    const boldTerm = (suggestion: string, _term: string) => {
-      const suggestionChars = suggestion.split(_term)
+    const suggestions =
+      SUGGESTED_PRODUCTS.length > 0
+        ? SUGGESTIONS.slice(0, MAX_SUGGESTIONS)
+        : SUGGESTIONS
+
+    const handleSuggestions = (suggestion: string, searchTerm: string) => {
+      const suggestionSubstring = suggestion
+        .toLowerCase()
+        .split(searchTerm.toLowerCase())
 
       return (
         <p>
-          {suggestionChars.map((char, index) => (
-            <>
-              {char}
-              {index !== suggestionChars.length - 1 && (
-                <b className="suggestions__bold-term">{_term}</b>
-              )}
-            </>
-          ))}
+          {suggestionSubstring.map((substring, indexSubstring) => {
+            const formatSearchTerm = () => {
+              if (indexSubstring === 0) {
+                return searchTerm
+                  .split('')
+                  .map((char, idx) =>
+                    idx === 0 && suggestion.indexOf(char.toUpperCase()) === 0
+                      ? char.toUpperCase()
+                      : char.toLowerCase()
+                  )
+              }
+
+              return searchTerm.toLowerCase()
+            }
+
+            return (
+              <>
+                <b className="suggestions__suggestion-bold">
+                  {indexSubstring === 0
+                    ? substring.charAt(0).toUpperCase() + substring.slice(1)
+                    : substring}
+                </b>
+                {indexSubstring !== suggestionSubstring.length - 1 &&
+                  formatSearchTerm()}
+              </>
+            )
+          })}
         </p>
       )
     }
 
     return (
-      <div
+      <section
         ref={ref}
         data-testid={testId}
         data-store-suggestions
         className="suggestions"
         {...otherProps}
       >
-        <UIList>
-          {SEARCH_SUGGESTIONS.map((suggestion, index) => (
-            <Link key={index} to="/">
-              {boldTerm(suggestion, term)}
-            </Link>
+        <UIList data-suggestions-list className="suggestions__section">
+          {suggestions.map((suggestion, index) => (
+            <Button
+              key={index}
+              onClick={() => null}
+              className="suggestions__suggestion"
+            >
+              {handleSuggestions(suggestion, term)}
+            </Button>
           ))}
         </UIList>
 
-        <div data-suggestions-suggested-products>
-          <p className="suggestions__suggested-products-title">
-            Suggested Products
-          </p>
+        <div className="suggestions__section">
+          <p className="suggestions__title">Suggested Products</p>
           <UIList>
-            {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS + 1).map(
+            {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS).map(
               (product, index) => (
                 <SuggestionProductCard key={index} product={product} />
               )
             )}
           </UIList>
         </div>
-      </div>
+      </section>
     )
   }
 )

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -2,6 +2,7 @@ import type { HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
 import { List as UIList } from '@faststore/ui'
 import Button from 'src/components/ui/Button'
+import Link from 'src/components/ui/Link'
 
 import SuggestionProductCard from '../SuggestionProductCard'
 
@@ -128,7 +129,9 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
               {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS).map(
                 (product, index) => (
                   <li key={index} className="suggestions__item">
-                    <SuggestionProductCard product={product} />
+                    <Link to="/" variant="display">
+                      <SuggestionProductCard product={product} />
+                    </Link>
                   </li>
                 )
               )}

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -7,7 +7,8 @@ import SuggestionProductCard from '../SuggestionProductCard'
 
 import './suggestions.scss'
 
-const MAX_SUGGESTIONS = 5
+const MAX_SUGGESTIONS = 10
+const MAX_SUGGESTIONS_WITH_PRODUCTS = 5
 const MAX_SUGGESTED_PRODUCTS = 4
 const SUGGESTED_PRODUCTS = [
   {
@@ -36,6 +37,25 @@ const SUGGESTED_PRODUCTS = [
 
 const SUGGESTIONS = ['Sony MX', 'Sony MV-100 Headphone', 'Sony M2000 Earbuds']
 
+function formatSearchTerm(
+  indexSubstring: number,
+  searchTerm: string,
+  suggestion: string
+) {
+  if (indexSubstring === 0) {
+    return searchTerm
+      .split('')
+      .map((char, idx) =>
+        idx === 0 && suggestion.indexOf(char.toUpperCase()) === 0
+          ? char.toUpperCase()
+          : char.toLowerCase()
+      )
+      .join('')
+  }
+
+  return searchTerm.toLowerCase()
+}
+
 export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * ID to find this component in testing tools (e.g.: cypress, testing library, and jest).
@@ -49,13 +69,13 @@ export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
 
 const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
   function Suggestions(
-    { testId = 'suggestions', term = '', ...otherProps },
+    { testId = 'suggestions', term = 'Son', ...otherProps },
     ref
   ) {
     const suggestions =
       SUGGESTED_PRODUCTS.length > 0
-        ? SUGGESTIONS.slice(0, MAX_SUGGESTIONS)
-        : SUGGESTIONS
+        ? SUGGESTIONS.slice(0, MAX_SUGGESTIONS_WITH_PRODUCTS)
+        : SUGGESTIONS.slice(0, MAX_SUGGESTIONS)
 
     const handleSuggestions = (suggestion: string, searchTerm: string) => {
       const suggestionSubstring = suggestion
@@ -64,33 +84,19 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
 
       return (
         <p>
-          {suggestionSubstring.map((substring, indexSubstring) => {
-            const formatSearchTerm = () => {
-              if (indexSubstring === 0) {
-                return searchTerm
-                  .split('')
-                  .map((char, idx) =>
-                    idx === 0 && suggestion.indexOf(char.toUpperCase()) === 0
-                      ? char.toUpperCase()
-                      : char.toLowerCase()
-                  )
-              }
-
-              return searchTerm.toLowerCase()
-            }
-
-            return (
-              <>
+          {suggestionSubstring.map((substring, indexSubstring) => (
+            <>
+              {substring.length > 0 && (
                 <b className="suggestions__suggestion-bold">
                   {indexSubstring === 0
                     ? substring.charAt(0).toUpperCase() + substring.slice(1)
                     : substring}
                 </b>
-                {indexSubstring !== suggestionSubstring.length - 1 &&
-                  formatSearchTerm()}
-              </>
-            )
-          })}
+              )}
+              {indexSubstring !== suggestionSubstring.length - 1 &&
+                formatSearchTerm(indexSubstring, searchTerm, suggestion)}
+            </>
+          ))}
         </p>
       )
     }
@@ -103,28 +109,35 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
         className="suggestions"
         {...otherProps}
       >
-        <UIList data-suggestions-list className="suggestions__section">
-          {suggestions.map((suggestion, index) => (
-            <Button
-              key={index}
-              onClick={() => null}
-              className="suggestions__suggestion"
-            >
-              {handleSuggestions(suggestion, term)}
-            </Button>
-          ))}
-        </UIList>
-
-        <div className="suggestions__section">
-          <p className="suggestions__title">Suggested Products</p>
-          <UIList>
-            {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS).map(
-              (product, index) => (
-                <SuggestionProductCard key={index} product={product} />
-              )
-            )}
+        {suggestions.length > 0 && (
+          <UIList data-suggestions-list className="suggestions__section">
+            {suggestions?.map((suggestion, index) => (
+              <li key={index}>
+                <Button
+                  onClick={() => null}
+                  className="suggestions__suggestion"
+                >
+                  {handleSuggestions(suggestion, term)}
+                </Button>
+              </li>
+            ))}
           </UIList>
-        </div>
+        )}
+
+        {SUGGESTED_PRODUCTS.length > 0 && (
+          <div className="suggestions__section">
+            <p className="suggestions__title">Suggested Products</p>
+            <UIList>
+              {SUGGESTED_PRODUCTS.slice(0, MAX_SUGGESTED_PRODUCTS).map(
+                (product, index) => (
+                  <li key={index}>
+                    <SuggestionProductCard product={product} />
+                  </li>
+                )
+              )}
+            </UIList>
+          </div>
+        )}
       </section>
     )
   }

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -52,7 +52,7 @@ export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
 
 const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
   function Suggestions(
-    { testId = 'suggestions', term = 'ny', ...otherProps },
+    { testId = 'suggestions', term = '', ...otherProps },
     ref
   ) {
     const boldTerm = (suggestion: string, _term: string) => {

--- a/src/components/search/Suggestions/Suggestions.tsx
+++ b/src/components/search/Suggestions/Suggestions.tsx
@@ -69,7 +69,7 @@ export interface SuggestionsProps extends HTMLAttributes<HTMLDivElement> {
 
 const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
   function Suggestions(
-    { testId = 'suggestions', term = 'Son', ...otherProps },
+    { testId = 'suggestions', term = '', ...otherProps },
     ref
   ) {
     const suggestions =
@@ -87,7 +87,7 @@ const Suggestions = forwardRef<HTMLDivElement, SuggestionsProps>(
           {suggestionSubstring.map((substring, indexSubstring) => (
             <>
               {substring.length > 0 && (
-                <b className="suggestions__suggestion-bold">
+                <b className="suggestions__item-bold">
                   {indexSubstring === 0
                     ? substring.charAt(0).toUpperCase() + substring.slice(1)
                     : substring}

--- a/src/components/search/Suggestions/SuggestionsTopSearch.tsx
+++ b/src/components/search/Suggestions/SuggestionsTopSearch.tsx
@@ -42,7 +42,7 @@ const SuggestionsTopSearch = forwardRef<
       <p className="suggestions__title">Top Search</p>
       <UIList variant="ordered">
         {searchedItems.map((item, index) => (
-          <li key={index}>
+          <li key={index} className="suggestions__item">
             <Link variant="display" to={item.href}>
               <Badge variant="info" small>
                 {index + 1}

--- a/src/components/search/Suggestions/index.ts
+++ b/src/components/search/Suggestions/index.ts
@@ -1,2 +1,4 @@
 export { default as SuggestionsTopSearch } from './SuggestionsTopSearch'
 export type { SuggestionsTopSearchProps } from './SuggestionsTopSearch'
+
+export { default } from './Suggestions'

--- a/src/components/search/Suggestions/index.ts
+++ b/src/components/search/Suggestions/index.ts
@@ -2,3 +2,4 @@ export { default as SuggestionsTopSearch } from './SuggestionsTopSearch'
 export type { SuggestionsTopSearchProps } from './SuggestionsTopSearch'
 
 export { default } from './Suggestions'
+export type { SuggestionsProps } from './Suggestions'

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -60,4 +60,10 @@
     background-color: transparent;
     cursor: pointer;
   }
+
+  [data-store-link] {
+    padding: var(--space-2) 0;
+    text-decoration: none;
+    outline: none;
+  }
 }

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -29,3 +29,31 @@
     }
   }
 }
+
+[data-store-suggestions] {
+  .suggestions__suggested-products-title {
+    margin-bottom: var(--space-1);
+    color: var(--color-neutral-7);
+    font-size: var(--text-size-3);
+  }
+
+  .suggestions__bold-term {
+    color: var(--color-neutral-7);
+    font-weight: --text-weight-bold;
+  }
+
+  [data-store-link] {
+    p {
+      color: var(--color-text-subtle);
+      font-size: var(--text-size-2);
+      line-height: 1.25;
+      text-decoration: none;
+      text-decoration-line: none;
+    }
+  }
+}
+
+[data-suggestions-suggested-products] {
+  padding: var(--space-3) var(--space-2);
+  border-top: var(--border-width-0) solid var(--color-border-display);
+}

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -2,16 +2,26 @@
 
 .suggestions__title {
   margin-bottom: var(--space-1);
+  padding: 0 var(--space-3);
   font-size: var(--text-size-3);
   line-height: 1.5;
 }
 
 .suggestions__section {
-  padding: var(--space-2) var(--space-3) var(--space-2);
+  padding: var(--space-2) 0;
   background-color: var(--bg-neutral-lightest);
 
   &:not(:last-child) {
     border-bottom: var(--border-width-0) solid var(--color-border-display);
+  }
+}
+
+.suggestions__item {
+  padding-right: var(--space-3);
+  padding-left: var(--space-3);
+
+  &:hover {
+    background-color: var(--color-secondary-0);
   }
 }
 
@@ -36,32 +46,16 @@
 }
 
 [data-store-suggestions] {
-  .suggestions__suggestion {
-    color: var(--color-text-subtle);
-    font-size: var(--text-size-2);
-    line-height: 1.25;
-  }
-
   .suggestions__suggestion-bold {
     color: var(--color-neutral-7);
     font-weight: var(--text-weight-bold);
   }
 
-  [data-store-button] {
-    display: inline-flex;
-    width: 100%;
-    padding: var(--space-2) var(--space-3);
+  .button[data-store-button] {
+    padding: var(--space-2) 0;
+    color: var(--color-text-subtle);
+    font-size: var(--text-size-2);
+    line-height: 1.25;
     background-color: transparent;
-    border: 0;
-    border-radius: 0;
-    cursor: pointer;
-
-    &:hover {
-      background-color: var(--color-secondary-0);
-    }
-  }
-
-  [data-suggestions-list] {
-    padding: var(--space-1) 0;
   }
 }

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -65,8 +65,3 @@
     padding: var(--space-1) 0;
   }
 }
-
-[data-suggestions-suggested-products] {
-  padding: var(--space-3) var(--space-2);
-  border-top: var(--border-width-0) solid var(--color-border-display);
-}

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -30,7 +30,7 @@
     margin-top: var(--space-1);
   }
 
-  li {
+  .suggestions__item {
     font-size: var(--text-size-2);
     line-height: 1.25;
 

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -46,7 +46,7 @@
 }
 
 [data-store-suggestions] {
-  .suggestions__suggestion-bold {
+  .suggestions__item-bold {
     color: var(--color-neutral-7);
     font-weight: var(--text-weight-bold);
   }
@@ -54,8 +54,10 @@
   .button[data-store-button] {
     padding: var(--space-2) 0;
     color: var(--color-text-subtle);
+    font-weight: var(--text-weight-regular);
     font-size: var(--text-size-2);
     line-height: 1.25;
     background-color: transparent;
+    cursor: pointer;
   }
 }

--- a/src/components/search/Suggestions/suggestions.scss
+++ b/src/components/search/Suggestions/suggestions.scss
@@ -1,13 +1,18 @@
 @import "src/styles/scaffold";
 
 .suggestions__title {
+  margin-bottom: var(--space-1);
   font-size: var(--text-size-3);
   line-height: 1.5;
 }
 
 .suggestions__section {
-  padding: var(--space-1) var(--space-3) var(--space-2);
+  padding: var(--space-2) var(--space-3) var(--space-2);
   background-color: var(--bg-neutral-lightest);
+
+  &:not(:last-child) {
+    border-bottom: var(--border-width-0) solid var(--color-border-display);
+  }
 }
 
 [data-store-suggestions-top-search] {
@@ -31,25 +36,33 @@
 }
 
 [data-store-suggestions] {
-  .suggestions__suggested-products-title {
-    margin-bottom: var(--space-1);
-    color: var(--color-neutral-7);
-    font-size: var(--text-size-3);
+  .suggestions__suggestion {
+    color: var(--color-text-subtle);
+    font-size: var(--text-size-2);
+    line-height: 1.25;
   }
 
-  .suggestions__bold-term {
+  .suggestions__suggestion-bold {
     color: var(--color-neutral-7);
-    font-weight: --text-weight-bold;
+    font-weight: var(--text-weight-bold);
   }
 
-  [data-store-link] {
-    p {
-      color: var(--color-text-subtle);
-      font-size: var(--text-size-2);
-      line-height: 1.25;
-      text-decoration: none;
-      text-decoration-line: none;
+  [data-store-button] {
+    display: inline-flex;
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--color-secondary-0);
     }
+  }
+
+  [data-suggestions-list] {
+    padding: var(--space-1) 0;
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add the `Suggestions` component. The purpose of this component is to encapsulate autocomplete suggestions and suggested products.

Note: The component has mock data as the integration will be done later.

## How does it work?

<img width="458" alt="Screen Shot 2022-03-10 at 11 24 32" src="https://user-images.githubusercontent.com/15722605/157681906-66b9955a-7232-4885-b71c-565eb6d55fe4.png">

## How to test it?

Since the component will be part of the `Suggestion`'s dropdown component, we don't have a specific place to render the component yet.

But one option is to render it in the `Navbar` component as shown below:

```
// line 84
<SearchInput
  onBlur={() => setSearchExpanded(false)}
  onFocus={() => setSearchExpanded(true)}
/>
```

```
// line 110
{searchExpanded && <Suggestions />}
```
<img width="519" alt="Screen Shot 2022-03-10 at 11 32 37" src="https://user-images.githubusercontent.com/15722605/157683673-b3eac261-1eab-405b-902c-6f4b09b4030e.png">
<img width="481" alt="Screen Shot 2022-03-10 at 11 32 50" src="https://user-images.githubusercontent.com/15722605/157683597-b390440b-30d7-4b91-a6b6-a3a656b9be50.png">

## References

[FSSS 191 - Search Suggestions component](https://vtex-dev.atlassian.net/browse/FSSS-191)

## Checklist

- [x] CHANGELOG entry added
