### PR TITLE
chore: Improve images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EmptyState` at the `ProductGallery` section.
 
 ### Changed
-
+- Removed fit-in property from image component
 - Moves icons to `/static/icons` folder
 - Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder
 - Replaces `let` declarations for `useRef` for better React compatibility

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -16,6 +16,15 @@ interface Props {
   item: ICartItem
 }
 
+const imgOptions = {
+  sourceWidth: 360,
+  aspectRatio: 1,
+  width: 72,
+  breakpoints: [50, 100, 150],
+  layout: 'constrained' as const,
+  backgroundColor: '#f0f0f0',
+}
+
 function CartItem({ item }: Props) {
   const btnProps = useRemoveButton(item)
   const { updateItemQuantity } = useCart()
@@ -32,15 +41,7 @@ function CartItem({ item }: Props) {
           <Image
             baseUrl={item.itemOffered.image[0].url}
             alt={item.itemOffered.image[0].alternateName}
-            sourceWidth={360}
-            aspectRatio={1}
-            width={72}
-            breakpoints={[50, 100, 150]}
-            layout="constrained"
-            backgroundColor="#f0f0f0"
-            options={{
-              fitIn: true,
-            }}
+            {...imgOptions}
           />
         </CardImage>
         <div data-cart-item-summary>

--- a/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
+++ b/src/components/search/SuggestionProductCard/SuggestionProductCard.tsx
@@ -21,6 +21,15 @@ const PRODUCTS = [
   },
 ]
 
+const imgOptions = {
+  width: 56,
+  sourceWidth: 360,
+  aspectRatio: 1,
+  breakpoints: [50, 100, 150],
+  layout: 'constrained' as const,
+  backgroundColor: '#f0f0f0',
+}
+
 function SuggestionProductCard({
   // TODO: Add Props interface and define `product` type
   product = PRODUCTS,
@@ -41,19 +50,7 @@ function SuggestionProductCard({
     >
       <CardContent>
         <CardImage>
-          <Image
-            baseUrl={img.url}
-            alt={img.alternateName}
-            width={56}
-            sourceWidth={360}
-            aspectRatio={1}
-            breakpoints={[50, 100, 150]}
-            layout="constrained"
-            backgroundColor="#f0f0f0"
-            options={{
-              fitIn: true,
-            }}
-          />
+          <Image baseUrl={img.url} alt={img.alternateName} {...imgOptions} />
         </CardImage>
         <div data-suggestion-product-card-summary>
           <p

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -22,6 +22,21 @@ interface HeroProps {
   imageAlt: string
 }
 
+const imgProps = {
+  aspectRatio: 2,
+  layout: 'fullWidth' as const,
+  loading: 'eager' as const,
+  // for mobile load 100vw image, for desktop load half img
+  sizes: '(max-width: 768px) 100vw, 53vw',
+  // reset gatsby image default style
+  style: {
+    overflow: undefined,
+    position: undefined,
+  },
+  backgroundColor: '#f0f0f0',
+  breakpoints: [720, 1080, 1440],
+}
+
 const Hero = ({
   title,
   subtitle,
@@ -59,24 +74,7 @@ const Hero = ({
         </div>
       </HeroContent>
       <HeroImage>
-        <Image
-          baseUrl={imageSrc}
-          alt={imageAlt}
-          aspectRatio={2}
-          layout="fullWidth"
-          backgroundColor="#f0f0f0"
-          loading="eager"
-          options={{
-            fitIn: true,
-          }}
-          // reset gatsby image default style
-          style={{
-            overflow: undefined,
-            position: undefined,
-          }}
-          // for mobile load 100vw image, for desktop load half img
-          sizes="(max-width: 768px) 100vw, 53vw"
-        />
+        <Image baseUrl={imageSrc} alt={imageAlt} {...imgProps} />
       </HeroImage>
     </UIHero>
   )

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -34,7 +34,7 @@ const imgProps = {
     position: undefined,
   },
   backgroundColor: '#f0f0f0',
-  breakpoints: [720, 1080, 1440],
+  breakpoints: [720, 1080, 1440, 1920],
 }
 
 const Hero = ({

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -26,8 +26,7 @@ const imgProps = {
   aspectRatio: 3 / 2,
   layout: 'fullWidth' as const,
   loading: 'eager' as const,
-  // for mobile load 100vw image, for desktop load half img
-  sizes: '(max-width: 768px) 100vw, 53vw',
+  sizes: '(max-width: 768px) 70vw, 50vw',
   // reset gatsby image default style
   style: {
     overflow: undefined,

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -23,7 +23,7 @@ interface HeroProps {
 }
 
 const imgProps = {
-  aspectRatio: 2,
+  aspectRatio: 3 / 2,
   layout: 'fullWidth' as const,
   loading: 'eager' as const,
   // for mobile load 100vw image, for desktop load half img

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -20,9 +20,6 @@ const detailsImage = {
   breakpoints: [250, 360, 480, 720],
   layout: 'constrained' as const,
   backgroundColor: '#f0f0f0',
-  options: {
-    fitIn: true,
-  },
 }
 
 function ImageGallery({ images }: ImageGalleryProps) {

--- a/src/components/ui/SkuSelector/SkuSelector.tsx
+++ b/src/components/ui/SkuSelector/SkuSelector.tsx
@@ -73,6 +73,15 @@ export interface SkuSelectorProps {
   onChange?: ChangeEventHandler<HTMLInputElement>
 }
 
+const imgOptions = {
+  sourceWidth: 720,
+  aspectRatio: 1,
+  width: 40,
+  breakpoints: [20, 40, 80],
+  layout: 'constrained' as const,
+  backgroundColor: '#f0f0f0',
+}
+
 function SkuSelector({
   label,
   variant,
@@ -119,19 +128,7 @@ function SkuSelector({
                 </span>
               )}
               {variant === 'image' && 'src' in option && (
-                <Image
-                  baseUrl={option.src}
-                  alt={option.alt}
-                  sourceWidth={720}
-                  aspectRatio={1}
-                  width={40}
-                  breakpoints={[20, 40, 80]}
-                  layout="constrained"
-                  backgroundColor="#f0f0f0"
-                  options={{
-                    fitIn: true,
-                  }}
-                />
+                <Image baseUrl={option.src} alt={option.alt} {...imgOptions} />
               )}
             </RadioOption>
           )


### PR DESCRIPTION
## What's the purpose of this pull request?
Improves image processing by using great thumbor features. 

## How does it work?
Thumbor has amazing tools regarding image cropping and resizing. To know more: https://thumbor.readthedocs.io/en/latest/usage.html#image-endpoint.  
We were extensively using one of these features called `fit-in`. This property is ok when the images behave badly, however, our UI thinks the images are nice and have the same aspect ratio. In this case we can drop out of using `fit-in` and save some bytes out of the images.

Also, another optimization this PR brings is to render img components once, by moving the creation of the `breakpoints` array outside the rendering cycle of the app. This should save some re-renders too.

Finally, hero's aspect-ratio image was wrong. On moto g4 the right aspect ratio was 3/2, not 2. The fix makes the browser work less to fit the image that comes from the server with the image that will be rendered on the screen. Below, a comparison of the images coming from the thumbor server. The second one makes the potato (moto g4) work much less than one the first one, because it has the same aspect-ratio of the final rendered image.

<div style="display: flex">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1753396/157121871-daebce49-0e0f-42c1-bb75-a9aae0a6a233.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1753396/157121813-edd60bf6-076b-4981-8cf3-11cfca9996e2.png">
</div>


## How to test it?
Everything should work as before

## Checklist
- [x] CHANGELOG entry added
