### PR TITLE
[FSSS-200] fix: Remove product card border on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Sections component with `content-visibility: auto`
 - Webpack Bundle analyzer
 - `GatsbyLink` to `Link` ui component.
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EmptyState` at the `ProductGallery` section.
 
 ### Changed
+
 - Removed fit-in property from image component
 - Moves icons to `/static/icons` folder
 - Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder
@@ -49,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix border style for Product Card and its skeleton on mobile
 - The divisor for the `Breadcrumb` component not rendering valid HTML.
 - useBuyButton/useRemoveButton hooks with inconsistent typings/behaviors
 - React tree re-rendering

--- a/src/components/product/ProductCard/product-card.scss
+++ b/src/components/product/ProductCard/product-card.scss
@@ -7,7 +7,7 @@
   min-width: 14rem;
   height: 100%;
   padding: var(--space-1) var(--space-1) var(--space-2);
-  border: 1px solid transparent;
+  border: var(--border-width-0) solid transparent;
   border-radius: var(--border-radius-default);
   transition: box-shadow .5s ease, border .5s ease;
 
@@ -20,7 +20,7 @@
 
   @media (hover: hover) {
     &:hover {
-      border: 1px solid var(--color-border-display);
+      border: var(--border-width-0) solid var(--color-border-display);
       box-shadow: var(--box-shadow);
     }
   }
@@ -46,7 +46,11 @@
   }
 
   &[data-card-bordered="true"] {
-    border: 1px solid var(--color-border-display);
+    border: none;
+
+    @include media(">=notebook") {
+      border: var(--border-width-0) solid var(--color-border-display);
+    }
   }
 
   &[data-card-out-of-stock="true"] {

--- a/src/components/product/ProductGrid/product-grid.scss
+++ b/src/components/product/ProductGrid/product-grid.scss
@@ -22,14 +22,4 @@
   li {
     background-color: var(--color-neutral-0);
   }
-
-  [data-store-card] {
-    &[data-card-bordered="true"] {
-      border: none;
-
-      @include media(">=notebook") {
-        border: 1px solid var(--color-border-display);
-      }
-    }
-  }
 }

--- a/src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss
+++ b/src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss
@@ -13,7 +13,13 @@
 
   @include media(">=notebook") { min-width: 12rem; }
 
-  &[data-bordered="true"] { border: var(--border-width-0) solid var(--color-border-display); }
+  &[data-bordered="true"] {
+    border: none;
+
+    @include media(">=notebook") {
+      border: var(--border-width-0) solid var(--color-border-display);
+    }
+  }
 
   [data-product-card-skeleton-image] {
     [data-element-variant="image"] {


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR removes the product card's border when rendering the component on mobile devices.

## How does it work?
Since the order that CSS loads is non-deterministic, we have to make sure that even if we shuffle the stylesheets, the styles are still being applied correctly. For achieving the final result, the media query was removed from the `product-grid.scss` file and included in both `product-card.scss` and `product-card-skeleton.scss`. 
By doing that we ensure that the styles aplied by the `product-card` stylesheets are not overwritten by the `product-grid` stylesheet when the loading order changes.
Following the mobile-first approach, we make the product cards borderless by default, and then add the `@include media(">=notebook")` media query into the product card's stylesheets to add borders on larger screen sizes. 

## How to test it?

- Open a product listing page on a larger screen, check that the product cards have borders.
- Switch to responsive layout in a smaller screen and check that the product cards are now borderless.

## References

Thanks to @hellofanny and @filipewl for the help.
