### PR TITLE
[FSSS-199] Implement/style Search results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SearchHistory` component.
 
 ### Changed
+
+- Changed ProductGallery and EmptyGallery styles to make the search results page
 - Moved all icons to use Icon component
 - Moved common/IconsSVG to ui/Icons
 - Moved EmptyState from common to ui folder
@@ -48,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - useWindowDimensions hook
 
 ### Removed
+
 - Removing hooks folder and migrating these hooks to sdk ou inline them on components
 - gatsby-plugin-offline due to CLS on recurrent users
 - useWindowDimensions hook

--- a/src/components/sections/ProductGallery/EmptyGallery.tsx
+++ b/src/components/sections/ProductGallery/EmptyGallery.tsx
@@ -14,24 +14,33 @@ function EmptyGallery({ searchTerm }: { searchTerm: string }) {
         </p>
       </header>
 
-      <LinkButton
-        to="/office"
-        variant="secondary"
-        icon={
-          <Icon name="CircleWavyWarning" width={18} height={18} weight="bold" />
-        }
-        iconPosition="left"
-      >
-        Browse Offers
-      </LinkButton>
-      <LinkButton
-        to="/technology"
-        variant="secondary"
-        icon={<Icon name="RocketLaunch" width={18} height={18} weight="bold" />}
-        iconPosition="left"
-      >
-        Just Arrived
-      </LinkButton>
+      <div>
+        <LinkButton
+          to="/office"
+          variant="secondary"
+          icon={
+            <Icon
+              name="CircleWavyWarning"
+              width={18}
+              height={18}
+              weight="bold"
+            />
+          }
+          iconPosition="left"
+        >
+          Browse Offers
+        </LinkButton>
+        <LinkButton
+          to="/technology"
+          variant="secondary"
+          icon={
+            <Icon name="RocketLaunch" width={18} height={18} weight="bold" />
+          }
+          iconPosition="left"
+        >
+          Just Arrived
+        </LinkButton>
+      </div>
     </EmptyState>
   )
 }

--- a/src/components/sections/ProductGallery/EmptyGallery.tsx
+++ b/src/components/sections/ProductGallery/EmptyGallery.tsx
@@ -3,12 +3,15 @@ import { LinkButton } from 'src/components/ui/Button'
 import EmptyState from 'src/components/ui/EmptyState'
 import Icon from 'src/components/ui/Icon'
 
-function EmptyGallery() {
+function EmptyGallery({ searchTerm }: { searchTerm: string }) {
   return (
     <EmptyState>
       <header>
         <Icon name="CircleWavyWarning" width={56} height={56} weight="thin" />
-        <p>Nothing matches with your search</p>
+        <p>
+          We couldn&apos;t find results for: <span>{searchTerm}</span>
+          <p>Try searching for a shorter term: Brand, Name or Feature.</p>
+        </p>
       </header>
 
       <LinkButton

--- a/src/components/sections/ProductGallery/EmptyGallery.tsx
+++ b/src/components/sections/ProductGallery/EmptyGallery.tsx
@@ -7,11 +7,10 @@ function EmptyGallery({ searchTerm }: { searchTerm: string }) {
   return (
     <EmptyState>
       <header>
-        <Icon name="CircleWavyWarning" width={56} height={56} weight="thin" />
         <p>
-          We couldn&apos;t find results for: <span>{searchTerm}</span>
-          <p>Try searching for a shorter term: Brand, Name or Feature.</p>
+          We couldn&apos;t find results for <span>{searchTerm}</span>
         </p>
+        <p>Try searching for a shorter term: Brand, Name or Feature.</p>
       </header>
 
       <div>

--- a/src/components/sections/ProductGallery/EmptyGallery.tsx
+++ b/src/components/sections/ProductGallery/EmptyGallery.tsx
@@ -3,43 +3,33 @@ import { LinkButton } from 'src/components/ui/Button'
 import EmptyState from 'src/components/ui/EmptyState'
 import Icon from 'src/components/ui/Icon'
 
-function EmptyGallery({ searchTerm }: { searchTerm: string }) {
+function EmptyGallery() {
   return (
     <EmptyState>
       <header>
-        <p>
-          We couldn&apos;t find results for <span>{searchTerm}</span>
-        </p>
-        <p>Try searching for a shorter term: Brand, Name or Feature.</p>
+        <Icon name="CircleWavyWarning" width={56} height={56} weight="thin" />
+
+        <p>Nothing matches with your search</p>
       </header>
 
-      <div>
-        <LinkButton
-          to="/office"
-          variant="secondary"
-          icon={
-            <Icon
-              name="CircleWavyWarning"
-              width={18}
-              height={18}
-              weight="bold"
-            />
-          }
-          iconPosition="left"
-        >
-          Browse Offers
-        </LinkButton>
-        <LinkButton
-          to="/technology"
-          variant="secondary"
-          icon={
-            <Icon name="RocketLaunch" width={18} height={18} weight="bold" />
-          }
-          iconPosition="left"
-        >
-          Just Arrived
-        </LinkButton>
-      </div>
+      <LinkButton
+        to="/office"
+        variant="secondary"
+        icon={
+          <Icon name="CircleWavyWarning" width={18} height={18} weight="bold" />
+        }
+        iconPosition="left"
+      >
+        Browse Offers
+      </LinkButton>
+      <LinkButton
+        to="/technology"
+        variant="secondary"
+        icon={<Icon name="RocketLaunch" width={18} height={18} weight="bold" />}
+        iconPosition="left"
+      >
+        Just Arrived
+      </LinkButton>
     </EmptyState>
   )
 }

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -21,9 +21,10 @@ const GalleryPageSkeleton = <ProductGrid page={0} pageSize={0} products={[]} />
 
 interface Props {
   title: string
+  searchTerm?: string
 }
 
-function ProductGallery({ title }: Props) {
+function ProductGallery({ title, searchTerm }: Props) {
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false)
   const { pages, state: searchState, addNextPage, addPrevPage } = useSearch()
   const { data } = useGalleryQuery()
@@ -34,13 +35,20 @@ function ProductGallery({ title }: Props) {
   if (data && totalCount === 0) {
     return (
       <Section className="product-listing / grid-content">
-        <EmptyGallery />
+        <EmptyGallery searchTerm={searchTerm ?? ''} />
       </Section>
     )
   }
 
   return (
     <Section className="product-listing / grid-content-full">
+      {searchTerm && (
+        <div className="product-listing__search-term / grid-content">
+          <h1>
+            Showing results for: <span>{searchTerm}</span>
+          </h1>
+        </div>
+      )}
       <div className="product-listing__content-grid / grid-content">
         <div className="product-listing__filters">
           <FilterSkeleton loading={facets?.length === 0}>

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -43,11 +43,11 @@ function ProductGallery({ title, searchTerm }: Props) {
   return (
     <Section className="product-listing / grid-content-full">
       {searchTerm && (
-        <div className="product-listing__search-term / grid-content">
+        <header className="product-listing__search-term / grid-content">
           <h1>
             Showing results for: <span>{searchTerm}</span>
           </h1>
-        </div>
+        </header>
       )}
       <div className="product-listing__content-grid / grid-content">
         <div className="product-listing__filters">

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -35,7 +35,7 @@ function ProductGallery({ title, searchTerm }: Props) {
   if (data && totalCount === 0) {
     return (
       <Section className="product-listing / grid-content">
-        <EmptyGallery searchTerm={searchTerm ?? ''} />
+        <EmptyGallery />
       </Section>
     )
   }

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -6,13 +6,15 @@
   height: 100%;
   padding-top: 0;
 
-  @include media("<notebook") {
-    padding-top: 0;
+  @include media(">=notebook") {
+    padding-top: var(--space-5);
   }
 }
 
 .product-listing__search-term {
-  margin-bottom: var(--space-3);
+  @include media(">=notebook") {
+    padding-bottom: var(--space-6);
+  }
 
   h1 {
     font-size: var(--text-size-4);

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -4,9 +4,25 @@
   --product-listing-row-height: var(--space-6);
 
   height: 100%;
+  padding-top: 0;
 
   @include media("<notebook") {
     padding-top: 0;
+  }
+}
+
+.product-listing__search-term {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 41.5px auto;
+
+  h1 {
+    font-size: var(--text-size-5);
+
+    span {
+      font-weight: var(--text-weight-bold);
+    }
   }
 }
 

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -15,7 +15,9 @@
   margin-bottom: var(--space-3);
 
   h1 {
-    font-size: var(--text-size-5);
+    font-size: var(--text-size-4);
+
+    @include media(">=tablet") { font-size: var(--text-size-5); }
 
     span {
       font-weight: var(--text-weight-bold);

--- a/src/components/sections/ProductGallery/product-gallery.scss
+++ b/src/components/sections/ProductGallery/product-gallery.scss
@@ -12,10 +12,7 @@
 }
 
 .product-listing__search-term {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  margin: 41.5px auto;
+  margin-bottom: var(--space-3);
 
   h1 {
     font-size: var(--text-size-5);

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -3,52 +3,32 @@
 .empty-state[data-empty-state] {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   height: 100%;
   min-height: 50vh;
   margin: var(--space-3) 0;
-  row-gap: var(--space-6);
+  padding: 0 var(--space-8);
+  background-color: var(--bg-neutral);
+  border-radius: var(--border-radius-default);
+  row-gap: var(--space-3);
 
-  @include media(">=notebook") { margin: var(--space-5) 0; }
+  @include media(">=tablet") {
+    align-items: center;
+    margin: var(--space-5) 0;
+  }
 
   > header {
     display: flex;
     flex-direction: column;
+    align-items: center;
+    justify-content: center;
     margin-bottom: var(--space-2);
-    color: var(--color-neutral-7);
-    row-gap: var(--space-4);
-
-    @include media(">=notebook") {
-      row-gap: var(--space-1);
-    }
+    color: var(--color-text-disabled);
+    row-gap: var(--space-1);
 
     p {
-      font-size: var(--text-size-4);
-      text-align: left;
-
-      @include media(">=notebook") {
-        font-size: var(--text-size-5);
-        text-align: center;
-      }
-
-      span {
-        font-weight: var(--text-weight-bold);
-      }
-    }
-
-    p:last-child {
       font-size: var(--text-size-3);
-    }
-  }
-
-  div {
-    display: flex;
-    flex-direction: column;
-    row-gap: var(--space-2);
-
-    @include media(">=notebook") {
-      flex-direction: row;
-      justify-content: center;
-      column-gap: var(--space-1);
+      text-align: center;
     }
   }
 

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -8,8 +8,6 @@
   height: 100%;
   min-height: 50vh;
   margin: var(--space-3) 0;
-  background-color: var(--bg-neutral);
-  border-radius: var(--border-radius-default);
   row-gap: var(--space-3);
 
   @include media(">=notebook") { margin: var(--space-5) 0; }
@@ -24,8 +22,25 @@
     row-gap: var(--space-1);
 
     p {
-      font-size: var(--text-size-3);
+      font-size: var(--text-size-5);
       text-align: center;
+
+      span {
+        font-weight: var(--text-weight-bold);
+      }
+
+      p {
+        font-size: var(--text-size-3);
+      }
+    }
+  }
+
+  div {
+    display: flex;
+    flex-direction: column;
+
+    [data-store-button] {
+      margin: var(--space-2);
     }
   }
 

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -3,44 +3,52 @@
 .empty-state[data-empty-state] {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
   height: 100%;
   min-height: 50vh;
   margin: var(--space-3) 0;
-  row-gap: var(--space-3);
+  row-gap: var(--space-6);
 
   @include media(">=notebook") { margin: var(--space-5) 0; }
 
   > header {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
     margin-bottom: var(--space-2);
-    color: var(--color-text-disabled);
-    row-gap: var(--space-1);
+    color: var(--color-neutral-7);
+    row-gap: var(--space-4);
+
+    @include media(">=notebook") {
+      row-gap: var(--space-1);
+    }
 
     p {
-      font-size: var(--text-size-5);
-      text-align: center;
+      font-size: var(--text-size-4);
+      text-align: left;
+
+      @include media(">=notebook") {
+        font-size: var(--text-size-5);
+        text-align: center;
+      }
 
       span {
         font-weight: var(--text-weight-bold);
       }
+    }
 
-      p {
-        font-size: var(--text-size-3);
-      }
+    p:last-child {
+      font-size: var(--text-size-3);
     }
   }
 
   div {
     display: flex;
     flex-direction: column;
+    row-gap: var(--space-2);
 
-    [data-store-button] {
-      margin: var(--space-2);
+    @include media(">=notebook") {
+      flex-direction: row;
+      justify-content: center;
+      column-gap: var(--space-1);
     }
   }
 

--- a/src/components/ui/ProductTitle/ProductTitle.tsx
+++ b/src/components/ui/ProductTitle/ProductTitle.tsx
@@ -5,15 +5,15 @@ import './product-title.scss'
 
 interface ProductTitleProp {
   /**
-   * A text such as the product's name.
+   * A react component to be used as the product title, e.g. an <h1>
    */
   title: ReactNode
   /**
-   * A text to be used with a label such to be used with a label
+   * A react component to be used as the product label, e.g. a <DiscountBadge>
    */
   label?: ReactNode
   /**
-   * A text to be used below such as the product's reference number.
+   * A text to be used below the title and the label, such as the product's reference number.
    */
   refNumber?: string
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,9 +53,17 @@ function Page(props: Props) {
           },
         }}
       />
+
       {/*
-        Sections: Components imported from '../components/sections' only.
-        Do not import or render components from any other folder in here.
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
       */}
       <Hero
         title="New Products Available"

--- a/src/pages/s.tsx
+++ b/src/pages/s.tsx
@@ -57,6 +57,17 @@ function Page(props: Props) {
 
       <SROnly as="h1" text={title} />
 
+      {/*
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
+      */}
       <Breadcrumb name="All Products" />
 
       <ProductGallery

--- a/src/pages/s.tsx
+++ b/src/pages/s.tsx
@@ -12,6 +12,7 @@ import type {
   SearchPageQueryQuery,
   SearchPageQueryQueryVariables,
 } from '@generated/graphql'
+import Breadcrumb from 'src/components/sections/Breadcrumb'
 
 export type Props = PageProps<
   SearchPageQueryQuery,
@@ -54,11 +55,9 @@ function Page(props: Props) {
         }}
       />
 
-      {/*
-        Sections: Components imported from '../components/sections' only.
-        Do not import or render components from any other folder in here.
-      */}
       <SROnly as="h1" text={title} />
+
+      <Breadcrumb name="All Products" />
 
       <ProductGallery
         title="Search Results"

--- a/src/pages/s.tsx
+++ b/src/pages/s.tsx
@@ -60,7 +60,10 @@ function Page(props: Props) {
       */}
       <SROnly as="h1" text={title} />
 
-      <ProductGallery title="Search Results" />
+      <ProductGallery
+        title="Search Results"
+        searchTerm={searchParams.term ?? undefined}
+      />
     </SearchProvider>
   )
 }

--- a/src/pages/{StoreCollection.slug}.tsx
+++ b/src/pages/{StoreCollection.slug}.tsx
@@ -92,6 +92,17 @@ function Page(props: Props) {
         itemListElements={collection?.breadcrumbList.itemListElement ?? []}
       />
 
+      {/*
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
+      */}
       <Breadcrumb
         breadcrumbList={collection?.breadcrumbList.itemListElement}
         name={title}

--- a/src/pages/{StoreCollection.slug}.tsx
+++ b/src/pages/{StoreCollection.slug}.tsx
@@ -92,10 +92,6 @@ function Page(props: Props) {
         itemListElements={collection?.breadcrumbList.itemListElement ?? []}
       />
 
-      {/*
-        Sections: Components imported from '../components/sections' only.
-        Do not import or render components from any other folder in here.
-      */}
       <Breadcrumb
         breadcrumbList={collection?.breadcrumbList.itemListElement}
         name={title}

--- a/src/pages/{StoreProduct.slug}/p.tsx
+++ b/src/pages/{StoreProduct.slug}/p.tsx
@@ -90,9 +90,17 @@ function Page(props: Props) {
       />
 
       {/*
-        Sections: Components imported from '../components/sections' only.
-        Do not import or render components from any other folder in here.
+        WARNING: Do not import or render components from any
+        other folder than '../components/sections' in here.
+
+        This is necessary to keep the integration with the CMS
+        easy and consistent, enabling the change and reorder
+        of elements on this page.
+
+        If needed, wrap your component in a <Section /> component
+        (not the HTML tag) before rendering it here.
       */}
+
       <ProductDetails product={product} />
 
       {youMightAlsoLikeProducts?.length > 0 && (


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR styles the search page results. Below are the images for reference.

- Desktop
<img width="975" alt="Screen Shot 2022-03-16 at 17 36 03" src="https://user-images.githubusercontent.com/24229855/158686169-134d1b23-bcc5-477e-80ad-495e2ee42378.png">
<img width="974" alt="Screen Shot 2022-03-16 at 17 36 30" src="https://user-images.githubusercontent.com/24229855/158686219-db260be0-41b0-427c-ba70-5a427bcf6295.png">

- Mobile
<img width="291" alt="Screen Shot 2022-03-16 at 17 37 24" src="https://user-images.githubusercontent.com/24229855/158686339-0bfee18c-9dcd-481d-b056-9f1cc3017cf7.png">
<img width="292" alt="Screen Shot 2022-03-16 at 17 37 41" src="https://user-images.githubusercontent.com/24229855/158686389-bb7c1b69-5877-42df-90c5-0fc6788e7f2f.png">

## How does it work?
Nothing unusual, just some extra props being passed and changes/additions in HTML/CSS here and there.

## How to test it?
- `yarn test`, verify that all tests still pass
- Run the development server
  - Search something that exists in the store (I usually use the word `tasty`)
    - Verify that the search page results show up and it is styled like the images above, both on mobile and desktop.
  - Search something that does not exist in the store (I usually use the phrase `brastemp washing machine`) 
    - Verify that the empty gallery (no results found) page renders and it is styled like the images above, both on mobile and desktop

## References
Thanks to @danzanzini for all the help

## Checklist
- [x] CHANGELOG entry added
