### PR TITLE
chore: Use Session postalCode instead of custom data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Hero` image responsive sizes for mobile and desktop.
 - `Badge` variants names
 - `Tiles` and `Tile` to use semantic list elements.
+- `postalCode` from storage to Session context.
 
 ### Deprecated
 
@@ -60,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display box from `<ProductCard/>` component
 - `useTotalCount` hook
 - Phosphor-react library
+- `main::store::postalCode` value from storage.
 
 ### Fixed
 

--- a/src/components/common/PostalCode/PostalCodeInput.tsx
+++ b/src/components/common/PostalCode/PostalCodeInput.tsx
@@ -1,25 +1,21 @@
-import { useStorage } from '@faststore/sdk'
+import { useSession } from '@faststore/sdk'
 import { Input as UIInput, Label as UILabel } from '@faststore/ui'
 import React, { useRef } from 'react'
 import type { KeyboardEvent } from 'react'
 
 import './postal-code-input.scss'
 
-const POSTAL_CODE_STORAGE_KEY = 'main::store::postalCode'
 const POSTAL_CODE_INPUT_ID = 'postal-code-input'
 
 export default function PostalCodeInput() {
   const ref = useRef<HTMLInputElement>(null)
-  const [postalCode, setPostalCode] = useStorage<string>(
-    POSTAL_CODE_STORAGE_KEY,
-    ''
-  )
+  const { setSession, postalCode } = useSession()
 
   const handleSubmit = (event: KeyboardEvent<HTMLInputElement>) => {
     const value = ref.current?.value
 
     if (event.key === 'Enter' && typeof value === 'string') {
-      setPostalCode(value)
+      setSession({ postalCode: value })
     }
   }
 
@@ -30,7 +26,7 @@ export default function PostalCodeInput() {
         id={POSTAL_CODE_INPUT_ID}
         ref={ref}
         onKeyDown={handleSubmit}
-        defaultValue={postalCode}
+        defaultValue={postalCode ?? ''}
       />
     </div>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
The postal code value was saved using a custom key (main::store::postalCode) on storage, but the postal code already exists on the Session context value.

## How does it work?
Use useSession context.

## How to test it?
Add a new value on Postal Code input, then see the result on storage(indexedDB)

## References

## Checklist
- [x] CHANGELOG entry added
