### PR TITLE
feat: Adds new Badge interactive variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IconSVG` component to load SVG Icons.
 - `Suggestions` component.
 - `SearchHistory` component.
+- `Badge` interactive variation.
 
 ### Changed
 - Move inline styles to external stylesheet to improve TBT

--- a/src/components/cart/CartSidebar/cart-sidebar.scss
+++ b/src/components/cart/CartSidebar/cart-sidebar.scss
@@ -12,8 +12,10 @@
     padding: var(--space-2) var(--page-padding-phone) var(--space-2);
     background-color: var(--bg-neutral-lightest);
 
-    [data-store-icon-button] {
-      margin-right: calc(-1 * var(--space-1));
+    > [data-store-icon-button] {
+      &:last-of-type {
+        margin-right: calc(-1 * var(--space-1));
+      }
     }
   }
 

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -1,18 +1,27 @@
 import { Badge as UIBadge } from '@faststore/ui'
 import type { ReactNode } from 'react'
 import React from 'react'
+import IconButton from 'src/components/ui/IconButton'
+import Icon from 'src/components/ui/Icon'
 
 import './badge.scss'
 
-export type BadgeVariants = 'info' | 'highlighted' | 'neutral'
+export type BadgeVariants = 'info' | 'highlighted' | 'neutral' | 'interactive'
 
 type Props = {
   small?: boolean
   variant?: BadgeVariants
   children: ReactNode
+  onClose?: () => void
 }
 
-const Badge = ({ small = false, variant, children, ...otherProps }: Props) => {
+const Badge = ({
+  small = false,
+  variant,
+  children,
+  onClose,
+  ...otherProps
+}: Props) => {
   return (
     <UIBadge
       className="badge"
@@ -20,7 +29,21 @@ const Badge = ({ small = false, variant, children, ...otherProps }: Props) => {
       data-store-badge-variant={variant}
       {...otherProps}
     >
-      {children}
+      <span>{children}</span>
+      {variant === 'interactive' && (
+        <IconButton
+          onClick={onClose}
+          aria-label="Remove badge"
+          icon={
+            <Icon
+              name="X"
+              weight="bold"
+              width={small ? 12 : 16}
+              height={small ? 12 : 16}
+            />
+          }
+        />
+      )}
     </UIBadge>
   )
 }

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -6,20 +6,22 @@ import Icon from 'src/components/ui/Icon'
 
 import './badge.scss'
 
-export type BadgeVariants = 'info' | 'highlighted' | 'neutral' | 'interactive'
+export type BadgeVariants = 'info' | 'highlighted' | 'neutral'
 
 type Props = {
   small?: boolean
   variant?: BadgeVariants
   children: ReactNode
   onClose?: () => void
+  interactive?: boolean
 }
 
 const Badge = ({
-  small = false,
   variant,
   children,
   onClose,
+  small = false,
+  interactive = false,
   ...otherProps
 }: Props) => {
   return (
@@ -27,10 +29,11 @@ const Badge = ({
       className="badge"
       data-store-badge={small ? 'small' : ''}
       data-store-badge-variant={variant}
+      data-store-badge-interactive={interactive}
       {...otherProps}
     >
       <span>{children}</span>
-      {variant === 'interactive' && (
+      {(interactive || onClose) && (
         <IconButton
           onClick={onClose}
           aria-label="Remove badge"

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -8,13 +8,23 @@ import './badge.scss'
 
 export type BadgeVariants = 'info' | 'highlighted' | 'neutral'
 
+type InteractiveBadge =
+  | {
+      interactive: true
+      onClose?: () => void
+    }
+  | {
+      interactive?: false
+      onClose?: never
+    }
+
 type Props = {
   small?: boolean
   variant?: BadgeVariants
   children: ReactNode
   onClose?: () => void
   interactive?: boolean
-}
+} & InteractiveBadge
 
 const Badge = ({
   variant,
@@ -33,7 +43,7 @@ const Badge = ({
       {...otherProps}
     >
       <span>{children}</span>
-      {(interactive || onClose) && (
+      {interactive && (
         <IconButton
           onClick={onClose}
           aria-label="Remove badge"

--- a/src/components/ui/Badge/badge.scss
+++ b/src/components/ui/Badge/badge.scss
@@ -22,23 +22,11 @@
       padding: var(--space-0) var(--space-2);
     }
   }
-}
 
-[data-store-badge-variant="neutral"] {
-  background-color: var(--bg-neutral);
-}
-
-[data-store-badge-variant="highlighted"] {
-  background-color: var(--bg-highlighted);
-}
-
-[data-store-badge-variant="info"] {
-  background-color: var(--bg-info);
-}
-
-[data-store-badge-variant="interactive"] {
-  > span {
-    padding-right: 0;
+  &[data-store-badge-interactive="true"] {
+    > span {
+      padding-right: 0;
+    }
   }
 
   [data-store-icon-button] {
@@ -52,6 +40,18 @@
       background-color: var(--color-secondary-1);
     }
   }
+}
+
+[data-store-badge-variant="neutral"] {
+  background-color: var(--bg-neutral);
+}
+
+[data-store-badge-variant="highlighted"] {
+  background-color: var(--bg-highlighted);
+}
+
+[data-store-badge-variant="info"] {
+  background-color: var(--bg-info);
 }
 
 [data-store-discount-badge-variant="low"] {

--- a/src/components/ui/Badge/badge.scss
+++ b/src/components/ui/Badge/badge.scss
@@ -1,7 +1,9 @@
 .badge[data-store-badge] {
+  display: flex;
+  align-content: stretch;
+  align-items: stretch;
   width: fit-content;
   height: fit-content;
-  padding: var(--space-1) var(--space-2);
   color: var(--color-text);
   font-weight: var(--text-weight-bold);
   font-size: var(--text-size-2);
@@ -9,9 +11,16 @@
   text-transform: uppercase;
   border-radius: var(--border-radius-pill);
 
+  > span {
+    padding: var(--space-1) var(--space-2);
+  }
+
   &[data-store-badge="small"] {
-    padding: var(--space-0) var(--space-2);
     font-size: var(--text-size-0);
+
+    > span {
+      padding: var(--space-0) var(--space-2);
+    }
   }
 }
 
@@ -25,6 +34,24 @@
 
 [data-store-badge-variant="info"] {
   background-color: var(--bg-info);
+}
+
+[data-store-badge-variant="interactive"] {
+  > span {
+    padding-right: 0;
+  }
+
+  [data-store-icon-button] {
+    width: var(--tap-min-size);
+    height: auto;
+    color: var(--color-neutral-7);
+    border-top-right-radius: var(--border-radius-pill);
+    border-bottom-right-radius: var(--border-radius-pill);
+
+    &:hover {
+      background-color: var(--color-secondary-1);
+    }
+  }
 }
 
 [data-store-discount-badge-variant="low"] {

--- a/src/components/ui/Badge/badge.scss
+++ b/src/components/ui/Badge/badge.scss
@@ -23,12 +23,6 @@
     }
   }
 
-  &[data-store-badge-interactive="true"] {
-    > span {
-      padding-right: 0;
-    }
-  }
-
   [data-store-icon-button] {
     width: var(--tap-min-size);
     height: auto;
@@ -36,8 +30,9 @@
     border-top-right-radius: var(--border-radius-pill);
     border-bottom-right-radius: var(--border-radius-pill);
 
-    &:hover {
-      background-color: var(--color-secondary-1);
+    &:hover, &:focus {
+      background-color: var(--color-black-transparent-10);
+      background-blend-mode: multiply;
     }
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to add a new `Badge` variant called `interactive`. This will be useful when the user needs an action to close/remove badges.

## How does it work?

**Default interactive badge:**

<img width="273" alt="Screen Shot 2022-03-17 at 16 48 04" src="https://user-images.githubusercontent.com/15722605/158883971-a04f56a2-b387-49e3-9fe0-636a0122bf6a.png"><img width="278" alt="Screen Shot 2022-03-17 at 16 48 13" src="https://user-images.githubusercontent.com/15722605/158883984-9b5edb7f-8db7-4781-bde3-283c046372c8.png">

**Small interactive badge:**
<img width="300" alt="Screen Shot 2022-03-17 at 16 46 34" src="https://user-images.githubusercontent.com/15722605/158884231-97b17328-3833-4f16-97a6-759109316b65.png"><img width="261" alt="Screen Shot 2022-03-17 at 16 48 26" src="https://user-images.githubusercontent.com/15722605/158884236-411e15d8-331f-4a24-a59d-e6a6e9c965ed.png">

## References

[FSSS 204 - Creates Badge Interactive variation](https://vtex-dev.atlassian.net/browse/FSSS-204?atlOrigin=eyJpIjoiZDgzY2IzZmU1ODY5NGY1YjlkNTljODlhOTQ5ZGZlMTAiLCJwIjoiaiJ9)

## Checklist

- [x] CHANGELOG entry added
