### PR TITLE
fix: CartItem's product's title and image size fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scroll lock when transitioning pages on mobile via `SlideOver` component navigation
 - Filter Button specificity on desktop
 - Filter facets are not being selected on mobile
+- Cart Item with wrong product's title and image size
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scroll lock when transitioning pages on mobile via `SlideOver` component navigation
 - Filter Button specificity on desktop
 - Filter facets are not being selected on mobile
-- Cart Item with wrong product's title and image size
+- `CartItem` image size and truncate long product's title
 
 ### Security
 

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -45,7 +45,9 @@ function CartItem({ item }: Props) {
           />
         </CardImage>
         <div data-cart-item-summary>
-          <p className="text-body">{item.itemOffered.isVariantOf.name}</p>
+          <p className="text-body" data-cart-item-title>
+            {item.itemOffered.isVariantOf.name}
+          </p>
           <span data-cart-item-prices>
             <Price
               value={item.listPrice}

--- a/src/components/cart/CartItem/cart-item.scss
+++ b/src/components/cart/CartItem/cart-item.scss
@@ -1,3 +1,5 @@
+@import "src/styles/scaffold";
+
 .cart-item {
   padding: var(--space-3);
   background-color: var(--bg-neutral-lightest);
@@ -5,8 +7,10 @@
   border-radius: var(--border-radius-default);
 
   [data-card-content] {
-    display: flex;
+    display: grid;
+    grid-template-columns: rem(72px) repeat(4, 1fr);
     align-items: center;
+    column-gap: var(--grid-gap-0);
   }
 
   [data-gatsby-image-wrapper] {
@@ -16,14 +20,18 @@
   }
 
   [data-cart-item-summary] {
-    display: flex;
     flex-direction: column;
-    margin-left: var(--space-3);
+    grid-column: 2 / span 4;
+  }
 
-    p {
-      margin-bottom: var(--space-0);
-      line-height: 1.2;
-    }
+  [data-cart-item-title] {
+    margin-bottom: var(--space-0);
+    color: inherit;
+    line-height: 1.2;
+    text-decoration: none;
+    outline: none;
+
+    @include truncate-title;
   }
 
   [data-cart-item-prices] {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the size of `CartItem`'s product's title and image.

## How does it work?

Before, for cases where the product title is long, the product image was shrunk:

<img width="466" alt="Screen Shot 2022-03-21 at 15 09 45" src="https://user-images.githubusercontent.com/15722605/159337783-e03fa990-e471-4805-9df2-e88933101fb8.png">

With the changes, this was fixed by truncating the product title (maximum of two lines) and the image size remains fixed.

<img width="473" alt="Screen Shot 2022-03-21 at 15 08 48" src="https://user-images.githubusercontent.com/15722605/159338176-d84b70ad-9602-4887-a0e9-09e606809e4f.png">

## References

[FSSS 213 - Fix image and product's title size on `CartItem`](https://vtex-dev.atlassian.net/browse/FSSS-213)

## Checklist

- [x] CHANGELOG entry added
