### PR TITLE
chore: Remove inline styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SearchHistory` component.
 
 ### Changed
-
+- Move inline styles to external stylesheet to improve TBT
 - Changed ProductGallery and EmptyGallery styles to make the search results page
 - Moved all icons to use Icon component
 - Moved common/IconsSVG to ui/Icons

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,38 +9,17 @@ exports.onPreInit = async ({ reporter }) => {
 }
 
 exports.onCreateWebpackConfig = ({ actions: { setWebpackConfig }, stage }) => {
-  const profiling = process.env.GATSBY_STORE_PROFILING === 'true'
+  const isProfilingEnabled = process.env.GATSBY_STORE_PROFILING === 'true'
 
-  if (stage === 'build-javascript') {
-    if (profiling) {
-      setWebpackConfig({
-        optimization: {
-          minimize: false,
-          moduleIds: 'named',
-          chunkIds: 'named',
-          concatenateModules: false,
-        },
-      })
-    } else {
-      setWebpackConfig({
-        optimization: {
-          runtimeChunk: {
-            name: `webpack-runtime`,
-          },
-          splitChunks: {
-            name: false,
-            cacheGroups: {
-              styles: {
-                name: `styles`,
-                test: /\.(css|scss)$/,
-                chunks: `initial`,
-                enforce: true,
-              },
-            },
-          },
-        },
-      })
-    }
+  if (stage === 'build-javascript' && isProfilingEnabled) {
+    setWebpackConfig({
+      optimization: {
+        minimize: false,
+        moduleIds: 'named',
+        chunkIds: 'named',
+        concatenateModules: false,
+      },
+    })
   }
 }
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -38,21 +38,35 @@ export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([<ThirdPartyScripts key="ThirdPartyScripts" />])
 }
 
+/**
+ * Gatsby inlines all styles from the app inside a `<style/>` tag. This decreases
+ * FCP, but increases TBT. Since we are having trouble with TBT, replacing `<style/>`
+ * with `<link/>` tags should lower TBT. This switch, however is not supported by
+ * Gatsby.
+ * A workaround described in https://github.com/gatsbyjs/gatsby/issues/1526 is
+ * implemented below
+ */
 export const onPreRenderHTML = ({
   getHeadComponents,
   replaceHeadComponents,
 }) => {
-  const headComponents = getHeadComponents()
+  if (process.env.NODE_ENV !== 'production') {
+    return
+  }
 
-  // enforce the global style before the others
-  const orderedComponents = headComponents.sort((item) => {
-    const isGlobalStyle =
-      item.type === 'style' &&
-      item.props['data-href'] &&
-      /^\/styles.[a-zA-Z0-9]*.css$/.test(item.props['data-href'])
+  const transformedHeadComponents = getHeadComponents().map((node) => {
+    if (node.type === 'style') {
+      const globalStyleHref = node.props['data-href']
 
-    return isGlobalStyle ? -1 : 1
+      if (globalStyleHref) {
+        return <link href={globalStyleHref} rel="stylesheet" type="text/css" />
+      }
+
+      return node
+    }
+
+    return node
   })
 
-  replaceHeadComponents(orderedComponents)
+  replaceHeadComponents(transformedHeadComponents)
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -59,7 +59,14 @@ export const onPreRenderHTML = ({
       const globalStyleHref = node.props['data-href']
 
       if (globalStyleHref) {
-        return <link href={globalStyleHref} rel="stylesheet" type="text/css" />
+        return (
+          <link
+            href={globalStyleHref}
+            rel="stylesheet"
+            type="text/css"
+            media="screen"
+          />
+        )
       }
 
       return node


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR replaces inline <style/> tags by <link/> tags.

## How does it work?
Inlining styles is good technique for decreasing FCP. It, however, increases TBT, since the browser processes both CSS and HTML in one go, instead of processing them on two different tasks.
This PR moves inline styles to an isolated stylesheet and removes CSS code splitting for the sake of simplicity. 

FCP shouldn't be penalized that much since this CSS is hashed and has an `immutable` cache header, which is heavily cached by the CDN.

Moving inline styles to a custom sheet is not natively supported by gatsby, so a hack had to be made. This hack is described in here: https://github.com/gatsbyjs/gatsby/issues/1526

## How to test it?
Nothing should have changed visually. However, PSI score should be bigger than master

## Checklist
- [x] CHANGELOG entry added
