### PR TITLE
chore: Styles and Integrates Image Gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Storybook configs (#463)
 - Adds vtex search tracking script. With this we will populate TopSearches and Autocomplete indices (#389)
 - Add `RegionalizationBar`, `RegionalizationButton` components and integrates it on Mobile and Desktop devices (#424).
+- Integrates and styles ImageGallery component at the PDP (#409)
 
 ### Changed
+
 - Applies new local tokens to `BannerText` (#470)
 - Update the Incentives component to handle CMS data (#474)
+- Refactors ImageGallery component to not use the useSlider component (#409)
 
 ### Deprecated
 
@@ -29,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removes CSS imports of components that are not being used (#476)
 
 ### Fixed
+
 - Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)
 - Fix unused CSS problem by separating imports into different files for each page (#473)
 - Potential layout shift on Hero section fixed (#472)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integrates and styles ImageGallery component at the PDP (#409)
 - Applies new local tokens to `Badge` (#462)
 - Applies new local tokens to `Hero` (#435)
 - Applies new local tokens to `Quantity Selector` (#448)
@@ -16,13 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds Storybook configs (#463)
 - Adds vtex search tracking script. With this we will populate TopSearches and Autocomplete indices (#389)
 - Add `RegionalizationBar`, `RegionalizationButton` components and integrates it on Mobile and Desktop devices (#424).
-- Integrates and styles ImageGallery component at the PDP (#409)
 
 ### Changed
 
+- Refactors ImageGallery component to not use the useSlider component (#409)
 - Applies new local tokens to `BannerText` (#470)
 - Update the Incentives component to handle CMS data (#474)
-- Refactors ImageGallery component to not use the useSlider component (#409)
 
 ### Deprecated
 

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { DiscountBadge } from 'src/components/ui/Badge'
 import Breadcrumb from 'src/components/ui/Breadcrumb'
 import { ButtonBuy } from 'src/components/ui/Button'
-import { Image } from 'src/components/ui/Image'
+import { ImageGallery } from 'src/components/ui/ImageGallery'
 import Price from 'src/components/ui/Price'
 import ProductTitle from 'src/components/ui/ProductTitle'
 import QuantitySelector from 'src/components/ui/QuantitySelector'
@@ -121,15 +121,7 @@ function ProductDetails({ product: staleProduct }: Props) {
         </header>
 
         <section className="product-details__image">
-          <Image
-            preload
-            loading="eager"
-            src={productImages[0].url}
-            alt={productImages[0].alternateName}
-            width={360}
-            height={270}
-            sizes="(max-width: 768px) 25vw, 50vw"
-          />
+          <ImageGallery images={productImages} />
         </section>
 
         <section className="product-details__settings">

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -120,9 +120,7 @@ function ProductDetails({ product: staleProduct }: Props) {
           />
         </header>
 
-        <section className="product-details__image">
-          <ImageGallery images={productImages} />
-        </section>
+        <ImageGallery images={productImages} />
 
         <section className="product-details__settings">
           <section className="product-details__values">

--- a/src/components/sections/ProductDetails/product-details.scss
+++ b/src/components/sections/ProductDetails/product-details.scss
@@ -17,29 +17,6 @@
   }
 }
 
-.product-details__image {
-  position: relative;
-  left: calc(-1 * var(--fs-grid-padding));
-  width: calc(100% + (2 * var(--fs-grid-padding)));
-
-  [data-gatsby-image-wrapper] {
-    @include media(">=tablet") {
-      border-radius: var(--fs-border-radius-default);
-      transform: translate3d(0, 0, 0);
-    }
-  }
-
-  @include media(">=tablet") {
-    left: 0;
-    grid-row: 1 / span 2;
-    grid-column: span 7;
-    width: 100%;
-    margin-bottom: var(--fs-spacing-7);
-  }
-
-  @include media(">=notebook") { grid-column: span 8; }
-}
-
 .product-details__content {
   margin-top: var(--fs-spacing-3);
   .product-details__description .text__title-subsection { margin-bottom: var(--fs-spacing-3); }

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -36,6 +36,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
           alt={currentImage.alternateName}
           width={250}
           height={250}
+          loading="eager"
         />
       </ImageZoom>
       <ImageGallerySelector itemsPerPage={4}>

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -13,6 +13,15 @@ interface ImageGalleryProps {
   images: ImageElementData[]
 }
 
+// const imgOptions = {
+//   sourceWidth: 1024,
+//   backgroundColor: '#f0f0f0',
+//   layout: 'constrained' as const,
+//   sizes: '(max-width: 768px) 25vw, 50vw',
+//   breakpoints: [360, 720, 1024],
+//   aspectRatio: 4 / 3,
+// }
+
 function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedImageIdx, setSelectedImageIdx] = useState(0)
   const currentImage = images[selectedImageIdx]

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@faststore/ui'
 import { useState } from 'react'
 import { Image } from 'src/components/ui/Image'
 
@@ -12,15 +11,6 @@ export interface ImageElementData {
 interface ImageGalleryProps {
   images: ImageElementData[]
 }
-
-// const imgOptions = {
-//   sourceWidth: 1024,
-//   backgroundColor: '#f0f0f0',
-//   layout: 'constrained' as const,
-//   sizes: '(max-width: 768px) 25vw, 50vw',
-//   breakpoints: [360, 720, 1024],
-//   aspectRatio: 4 / 3,
-// }
 
 function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedImageIdx, setSelectedImageIdx] = useState(0)
@@ -40,32 +30,11 @@ function ImageGallery({ images }: ImageGalleryProps) {
         />
       </ImageZoom>
       {images.length > 1 && (
-        <ImageGallerySelector itemsPerPage={4}>
-          {images.map((image, idx) => {
-            return (
-              <Button
-                key={idx}
-                data-thumbnail-button={
-                  idx === selectedImageIdx ? 'selected' : 'true'
-                }
-                aria-label={`Load ${image.alternateName} - Image ${
-                  idx + 1
-                } of ${images.length}`}
-                onClick={() => {
-                  setSelectedImageIdx(idx)
-                }}
-              >
-                <Image
-                  src={image.url}
-                  alt={image.alternateName}
-                  loading={idx === 0 ? 'eager' : 'lazy'}
-                  width={250}
-                  height={250}
-                />
-              </Button>
-            )
-          })}
-        </ImageGallerySelector>
+        <ImageGallerySelector
+          images={images}
+          currentImageIdx={selectedImageIdx}
+          onSelect={setSelectedImageIdx}
+        />
       )}
     </section>
   )

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -4,8 +4,6 @@ import { Image } from 'src/components/ui/Image'
 
 import { ImageGallerySelector, ImageZoom } from '.'
 
-import './image-gallery.scss'
-
 export interface ImageElementData {
   url: string
   alternateName: string
@@ -29,7 +27,9 @@ function ImageGallery({ images }: ImageGalleryProps) {
   const currentImage = images[selectedImageIdx]
 
   return (
-    <section data-image-gallery={images.length > 1 ? 'has-selector' : 'true'}>
+    <section
+      data-fs-image-gallery={images.length > 1 ? 'has-selector' : 'true'}
+    >
       <ImageZoom>
         <Image
           src={currentImage.url}

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -29,7 +29,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
   const currentImage = images[selectedImageIdx]
 
   return (
-    <section data-image-gallery>
+    <section data-image-gallery={images.length > 1 ? 'has-selector' : 'true'}>
       <ImageZoom>
         <Image
           src={currentImage.url}

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -22,8 +22,9 @@ function ImageGallery({ images }: ImageGalleryProps) {
         <Image
           src={currentImage.url}
           alt={currentImage.alternateName}
-          width={712}
-          height={450}
+          sizes="(max-width: 804px) 25vw, 30vw"
+          width={804}
+          height={804 * (3 / 4)}
           loading="eager"
         />
       </ImageZoom>

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -17,15 +17,13 @@ function ImageGallery({ images }: ImageGalleryProps) {
   const currentImage = images[selectedImageIdx]
 
   return (
-    <section
-      data-fs-image-gallery={images.length > 1 ? 'has-selector' : 'true'}
-    >
+    <section data-fs-image-gallery>
       <ImageZoom>
         <Image
           src={currentImage.url}
           alt={currentImage.alternateName}
-          width={250}
-          height={250}
+          width={712}
+          height={450}
           loading="eager"
         />
       </ImageZoom>

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -39,32 +39,34 @@ function ImageGallery({ images }: ImageGalleryProps) {
           loading="eager"
         />
       </ImageZoom>
-      <ImageGallerySelector itemsPerPage={4}>
-        {images.map((image, idx) => {
-          return (
-            <Button
-              key={idx}
-              data-thumbnail-button={
-                idx === selectedImageIdx ? 'selected' : 'true'
-              }
-              aria-label={`Load ${image.alternateName} - Image ${idx + 1} of ${
-                images.length
-              }`}
-              onClick={() => {
-                setSelectedImageIdx(idx)
-              }}
-            >
-              <Image
-                src={image.url}
-                alt={image.alternateName}
-                loading={idx === 0 ? 'eager' : 'lazy'}
-                width={250}
-                height={250}
-              />
-            </Button>
-          )
-        })}
-      </ImageGallerySelector>
+      {images.length > 1 && (
+        <ImageGallerySelector itemsPerPage={4}>
+          {images.map((image, idx) => {
+            return (
+              <Button
+                key={idx}
+                data-thumbnail-button={
+                  idx === selectedImageIdx ? 'selected' : 'true'
+                }
+                aria-label={`Load ${image.alternateName} - Image ${
+                  idx + 1
+                } of ${images.length}`}
+                onClick={() => {
+                  setSelectedImageIdx(idx)
+                }}
+              >
+                <Image
+                  src={image.url}
+                  alt={image.alternateName}
+                  loading={idx === 0 ? 'eager' : 'lazy'}
+                  width={250}
+                  height={250}
+                />
+              </Button>
+            )
+          })}
+        </ImageGallerySelector>
+      )}
     </section>
   )
 }

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -4,6 +4,8 @@ import { Image } from 'src/components/ui/Image'
 
 import { ImageGallerySelector, ImageZoom } from '.'
 
+import './image-gallery.scss'
+
 export interface ImageElementData {
   url: string
   alternateName: string
@@ -27,7 +29,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
   const currentImage = images[selectedImageIdx]
 
   return (
-    <div>
+    <section data-image-gallery>
       <ImageZoom>
         <Image
           src={currentImage.url}
@@ -62,7 +64,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
           )
         })}
       </ImageGallerySelector>
-    </div>
+    </section>
   )
 }
 

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -1,10 +1,14 @@
-import { Children, useRef } from 'react'
-import type { HTMLAttributes, PropsWithChildren } from 'react'
-import { IconButton } from '@faststore/ui'
+import { useRef } from 'react'
+import { Button, IconButton } from '@faststore/ui'
 import Icon from 'src/components/ui/Icon'
+import { Image } from 'src/components/ui/Image'
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
-  itemsPerPage: number
+import type { ImageElementData } from './ImageGallery'
+
+interface Props {
+  images: ImageElementData[]
+  onSelect: React.Dispatch<React.SetStateAction<number>>
+  currentImageIdx: number
 }
 
 const moveScroll = (container: HTMLDivElement | null, value: number) => {
@@ -17,13 +21,7 @@ const moveScroll = (container: HTMLDivElement | null, value: number) => {
   }
 }
 
-function ImageGallerySelector({
-  itemsPerPage,
-  children,
-}: PropsWithChildren<Props>) {
-  const elements = Children.toArray(children)
-  const elementCount = elements.length
-
+function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   const elementsRef = useRef<HTMLDivElement>(null)
 
   return (
@@ -32,7 +30,7 @@ function ImageGallerySelector({
       aria-roledescription="carousel"
       aria-label="Product images"
     >
-      {elementCount > itemsPerPage && (
+      {true && (
         <IconButton
           aria-label="backward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
@@ -40,11 +38,30 @@ function ImageGallerySelector({
         />
       )}
       <div data-fs-image-gallery-selector-elements ref={elementsRef}>
-        {elements.map((el, idx) => {
-          return <div key={idx}>{el}</div>
+        {images.map((image, idx) => {
+          return (
+            <Button
+              key={idx}
+              data-thumbnail-button={
+                idx === currentImageIdx ? 'selected' : 'true'
+              }
+              aria-label={`Load ${image.alternateName} - Image ${idx + 1} of ${
+                images.length
+              }`}
+              onClick={() => onSelect(idx)}
+            >
+              <Image
+                src={image.url}
+                alt={image.alternateName}
+                loading={idx === 0 ? 'eager' : 'lazy'}
+                width={250}
+                height={250}
+              />
+            </Button>
+          )
         })}
       </div>
-      {elementCount > itemsPerPage && (
+      {true && (
         <IconButton
           aria-label="forward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -47,24 +47,40 @@ function ImageGallerySelector({
       data-image-gallery-selector
       aria-roledescription="carousel"
       aria-label="Product images"
+      {...handlers}
     >
-      <IconButton
-        aria-label="backward slide image selector"
-        icon={<BackwardArrowIcon color="#323845" />}
-        onClick={() => {
-          if (sliderState.sliding) {
-            return
-          }
+      {elementCount > itemsPerPage && (
+        <>
+          <IconButton
+            aria-label="backward slide image selector"
+            icon={<BackwardArrowIcon color="#323845" />}
+            onClick={() => {
+              if (sliderState.sliding) {
+                return
+              }
 
-          slide('previous', sliderDispatch)
-        }}
-      />
+              slide('previous', sliderDispatch)
+            }}
+          />
+          <IconButton
+            aria-label="forward slide image selector"
+            icon={<ForwardArrowIcon color="#323845" />}
+            onClick={() => {
+              if (sliderState.sliding) {
+                return
+              }
+
+              slide('next', sliderDispatch)
+            }}
+          />
+        </>
+      )}
       <div
         data-carousel-track
         style={{
           display: 'flex',
           transition: sliderState.sliding ? `transform 400ms` : undefined,
-          width: `${(elementCount * 100) / itemsPerPage}%`,
+          // width: `${(elementCount * 100) / itemsPerPage}%`,
           transform: `translate3d(${getTransformValue(
             elementCount,
             sliderState.currentPage,
@@ -96,27 +112,11 @@ function ImageGallerySelector({
             })
           }
         }}
-        {...handlers}
       >
         {elements.map((el, idx) => {
-          return (
-            <div data-image-gallery-selector-thumb-image key={idx}>
-              {el}
-            </div>
-          )
+          return <div key={idx}>{el}</div>
         })}
       </div>
-      <IconButton
-        aria-label="forward slide image selector"
-        icon={<ForwardArrowIcon color="#323845" />}
-        onClick={() => {
-          if (sliderState.sliding) {
-            return
-          }
-
-          slide('next', sliderDispatch)
-        }}
-      />
     </section>
   )
 }

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -21,6 +21,17 @@ const moveScroll = (container: HTMLDivElement | null, value: number) => {
   }
 }
 
+const hasScroll = (container: HTMLDivElement | null): boolean => {
+  if (container) {
+    return (
+      container.scrollHeight > container.clientHeight ||
+      container.scrollWidth > container.clientWidth
+    )
+  }
+
+  return false
+}
+
 function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   const elementsRef = useRef<HTMLDivElement>(null)
 
@@ -30,7 +41,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
       aria-roledescription="carousel"
       aria-label="Product images"
     >
-      {true && (
+      {hasScroll(elementsRef.current) && (
         <IconButton
           aria-label="backward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
@@ -61,7 +72,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
           )
         })}
       </div>
-      {true && (
+      {hasScroll(elementsRef.current) && (
         <IconButton
           aria-label="forward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -4,6 +4,8 @@ import type { HTMLAttributes, PropsWithChildren } from 'react'
 
 import { BackwardArrowIcon, ForwardArrowIcon } from './Icons'
 
+import './image-gallery-selector.scss'
+
 interface Props extends HTMLAttributes<HTMLDivElement> {
   itemsPerPage: number
 }
@@ -42,7 +44,11 @@ function ImageGallerySelector({
   }
 
   return (
-    <section aria-roledescription="carousel" aria-label="Product images">
+    <section
+      data-image-gallery-selector
+      aria-roledescription="carousel"
+      aria-label="Product images"
+    >
       <IconButton
         aria-label="backward slide image selector"
         icon={<BackwardArrowIcon color="#323845" />}
@@ -54,18 +60,6 @@ function ImageGallerySelector({
           slide('previous', sliderDispatch)
         }}
       />
-      <IconButton
-        aria-label="forward slide image selector"
-        icon={<ForwardArrowIcon color="#323845" />}
-        onClick={() => {
-          if (sliderState.sliding) {
-            return
-          }
-
-          slide('next', sliderDispatch)
-        }}
-      />
-
       <div {...otherProps} {...handlers}>
         <div
           data-carousel-track
@@ -108,14 +102,23 @@ function ImageGallerySelector({
           {elements.map((el, idx) => {
             return (
               <div key={idx} style={{ width: `${100 / elementCount}%` }}>
-                <div className="flex justify-center items-center w-full">
-                  {el}
-                </div>
+                <div>{el}</div>
               </div>
             )
           })}
         </div>
       </div>
+      <IconButton
+        aria-label="forward slide image selector"
+        icon={<ForwardArrowIcon color="#323845" />}
+        onClick={() => {
+          if (sliderState.sliding) {
+            return
+          }
+
+          slide('next', sliderDispatch)
+        }}
+      />
     </section>
   )
 }

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -42,81 +42,82 @@ function ImageGallerySelector({
     return null
   }
 
+  const transformValue = getTransformValue(
+    elementCount,
+    sliderState.currentPage,
+    itemsPerPage
+  )
+
   return (
     <section
       data-image-gallery-selector
       aria-roledescription="carousel"
       aria-label="Product images"
-      {...handlers}
     >
-      {elementCount > itemsPerPage && (
-        <>
-          <IconButton
-            aria-label="backward slide image selector"
-            icon={<BackwardArrowIcon color="#323845" />}
-            onClick={() => {
-              if (sliderState.sliding) {
-                return
-              }
+      {elementCount > itemsPerPage && sliderState.currentPage !== 0 && (
+        <IconButton
+          aria-label="backward slide image selector"
+          icon={<BackwardArrowIcon color="#323845" />}
+          onClick={() => {
+            if (sliderState.sliding) {
+              return
+            }
 
-              slide('previous', sliderDispatch)
-            }}
-          />
-          <IconButton
-            aria-label="forward slide image selector"
-            icon={<ForwardArrowIcon color="#323845" />}
-            onClick={() => {
-              if (sliderState.sliding) {
-                return
-              }
-
-              slide('next', sliderDispatch)
-            }}
-          />
-        </>
+            slide('previous', sliderDispatch)
+          }}
+        />
       )}
-      <div
-        data-carousel-track
-        style={{
-          display: 'flex',
-          transition: sliderState.sliding ? `transform 400ms` : undefined,
-          // width: `${(elementCount * 100) / itemsPerPage}%`,
-          transform: `translate3d(${getTransformValue(
-            elementCount,
-            sliderState.currentPage,
-            itemsPerPage
-          )}%, 0, 0)`,
-        }}
-        onTransitionEnd={() => {
-          sliderDispatch({
-            type: 'STOP_SLIDE',
-          })
-
-          if (sliderState.currentItem >= elementCount) {
+      <div data-carousel-track-container {...handlers}>
+        <div
+          data-carousel-track
+          style={{
+            width: `${(elementCount * 100) / itemsPerPage}%`,
+            transform: `translate3d(${transformValue}%, 0, 0)`,
+          }}
+          onTransitionEnd={() => {
             sliderDispatch({
-              type: 'GO_TO_PAGE',
-              payload: {
-                pageIndex: 0,
-                shouldSlide: false,
-              },
+              type: 'STOP_SLIDE',
             })
-          }
 
-          if (sliderState.currentItem < 0) {
-            sliderDispatch({
-              type: 'GO_TO_PAGE',
-              payload: {
-                pageIndex: sliderState.totalPages - 1,
-                shouldSlide: false,
-              },
-            })
-          }
-        }}
-      >
-        {elements.map((el, idx) => {
-          return <div key={idx}>{el}</div>
-        })}
+            if (sliderState.currentItem >= elementCount) {
+              sliderDispatch({
+                type: 'GO_TO_PAGE',
+                payload: {
+                  pageIndex: 0,
+                  shouldSlide: false,
+                },
+              })
+            }
+
+            if (sliderState.currentItem < 0) {
+              sliderDispatch({
+                type: 'GO_TO_PAGE',
+                payload: {
+                  pageIndex: sliderState.totalPages - 1,
+                  shouldSlide: false,
+                },
+              })
+            }
+          }}
+        >
+          {elements.map((el, idx) => {
+            return <div key={idx}>{el}</div>
+          })}
+        </div>
       </div>
+      {elementCount > itemsPerPage && (
+        <IconButton
+          aria-label="forward slide image selector"
+          icon={<ForwardArrowIcon color="#323845" />}
+          onClick={() => {
+            if (sliderState.sliding) {
+              return
+            }
+
+            slide('next', sliderDispatch)
+          }}
+        />
+      )}
     </section>
   )
 }

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -10,21 +10,6 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   itemsPerPage: number
 }
 
-function getTransformValue(
-  totalItems: number,
-  currentPage: number,
-  itemsPerPage: number
-) {
-  // We use 100 to represent the full width of the parent element
-  const slideWidth = 100 / totalItems
-
-  // slideWidth gives us the full width value for sliding through all elements.
-  // We then multiply the slideWidth by (currentPage * itemsPerPage) to calculate the
-  // transformValue for each page (the more we slide forward, the more we have to slide in total).
-  // It is negative so the transition slides the items to the left.
-  return -(slideWidth * currentPage * itemsPerPage)
-}
-
 function ImageGallerySelector({
   itemsPerPage,
   children,
@@ -32,21 +17,9 @@ function ImageGallerySelector({
   const elements = Children.toArray(children)
   const elementCount = elements.length
 
-  const { handlers, slide, sliderState, sliderDispatch } = useSlider({
-    totalItems: elementCount,
-    itemsPerPage,
-    infiniteMode: false,
-  })
-
   if (!elementCount) {
     return null
   }
-
-  const transformValue = getTransformValue(
-    elementCount,
-    sliderState.currentPage,
-    itemsPerPage
-  )
 
   return (
     <section
@@ -54,67 +27,42 @@ function ImageGallerySelector({
       aria-roledescription="carousel"
       aria-label="Product images"
     >
-      {elementCount > itemsPerPage && sliderState.currentPage !== 0 && (
+      {elementCount > itemsPerPage && (
         <IconButton
           aria-label="backward slide image selector"
           icon={<BackwardArrowIcon color="#323845" />}
           onClick={() => {
-            if (sliderState.sliding) {
-              return
-            }
+            const container = document.getElementById('myScrollSlider')
 
-            slide('previous', sliderDispatch)
+            if (container) {
+              if (container.scrollHeight > container.clientHeight) {
+                container.scrollTop -= 200
+              } else {
+                container.scrollLeft -= 200
+              }
+            }
           }}
         />
       )}
-      <div data-carousel-track-container {...handlers}>
-        <div
-          data-carousel-track
-          style={{
-            width: `${(elementCount * 100) / itemsPerPage}%`,
-            transform: `translate3d(${transformValue}%, 0, 0)`,
-          }}
-          onTransitionEnd={() => {
-            sliderDispatch({
-              type: 'STOP_SLIDE',
-            })
-
-            if (sliderState.currentItem >= elementCount) {
-              sliderDispatch({
-                type: 'GO_TO_PAGE',
-                payload: {
-                  pageIndex: 0,
-                  shouldSlide: false,
-                },
-              })
-            }
-
-            if (sliderState.currentItem < 0) {
-              sliderDispatch({
-                type: 'GO_TO_PAGE',
-                payload: {
-                  pageIndex: sliderState.totalPages - 1,
-                  shouldSlide: false,
-                },
-              })
-            }
-          }}
-        >
-          {elements.map((el, idx) => {
-            return <div key={idx}>{el}</div>
-          })}
-        </div>
+      <div id="myScrollSlider" data-carousel-track>
+        {elements.map((el, idx) => {
+          return <div key={idx}>{el}</div>
+        })}
       </div>
       {elementCount > itemsPerPage && (
         <IconButton
           aria-label="forward slide image selector"
           icon={<ForwardArrowIcon color="#323845" />}
           onClick={() => {
-            if (sliderState.sliding) {
-              return
-            }
+            const container = document.getElementById('myScrollSlider')
 
-            slide('next', sliderDispatch)
+            if (container) {
+              if (container?.scrollHeight > container?.clientHeight) {
+                container.scrollTop += 200
+              } else {
+                container.scrollLeft += 200
+              }
+            }
           }}
         />
       )}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -3,10 +3,18 @@ import type { HTMLAttributes, PropsWithChildren } from 'react'
 import { IconButton } from '@faststore/ui'
 import Icon from 'src/components/ui/Icon'
 
-import './image-gallery-selector.scss'
-
 interface Props extends HTMLAttributes<HTMLDivElement> {
   itemsPerPage: number
+}
+
+const moveScroll = (container: HTMLDivElement | null, value: number) => {
+  if (container) {
+    if (container.scrollHeight > container.clientHeight) {
+      container.scrollTop += value
+    } else {
+      container.scrollLeft += value
+    }
+  }
 }
 
 function ImageGallerySelector({
@@ -18,19 +26,9 @@ function ImageGallerySelector({
 
   const elementsRef = useRef<HTMLDivElement>(null)
 
-  const moveScroll = (container: HTMLDivElement | null, value: number) => {
-    if (container) {
-      if (container.scrollHeight > container.clientHeight) {
-        container.scrollTop += value
-      } else {
-        container.scrollLeft += value
-      }
-    }
-  }
-
   return (
     <section
-      data-image-gallery-selector
+      data-fs-image-gallery-selector
       aria-roledescription="carousel"
       aria-label="Product images"
     >
@@ -41,7 +39,7 @@ function ImageGallerySelector({
           onClick={() => moveScroll(elementsRef.current, -200)}
         />
       )}
-      <div data-carousel-track ref={elementsRef}>
+      <div data-fs-image-gallery-selector-elements ref={elementsRef}>
         {elements.map((el, idx) => {
           return <div key={idx}>{el}</div>
         })}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -29,7 +29,7 @@ function ImageGallerySelector({
       {elementCount > itemsPerPage && (
         <IconButton
           aria-label="backward slide image selector"
-          icon={<Icon name="ArrowLeft" />}
+          icon={<Icon name="ArrowLeft" width={24} height={24} />}
           onClick={() => {
             const container = document.getElementById('myScrollSlider')
 
@@ -51,7 +51,7 @@ function ImageGallerySelector({
       {elementCount > itemsPerPage && (
         <IconButton
           aria-label="forward slide image selector"
-          icon={<Icon name="ArrowRight" />}
+          icon={<Icon name="ArrowLeft" width={24} height={24} />}
           onClick={() => {
             const container = document.getElementById('myScrollSlider')
 

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -1,4 +1,4 @@
-import { Children } from 'react'
+import { Children, useRef } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 import { IconButton } from '@faststore/ui'
 import Icon from 'src/components/ui/Icon'
@@ -16,8 +16,16 @@ function ImageGallerySelector({
   const elements = Children.toArray(children)
   const elementCount = elements.length
 
-  if (!elementCount) {
-    return null
+  const elementsRef = useRef<HTMLDivElement>(null)
+
+  const moveScroll = (container: HTMLDivElement | null, value: number) => {
+    if (container) {
+      if (container.scrollHeight > container.clientHeight) {
+        container.scrollTop += value
+      } else {
+        container.scrollLeft += value
+      }
+    }
   }
 
   return (
@@ -30,20 +38,10 @@ function ImageGallerySelector({
         <IconButton
           aria-label="backward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
-          onClick={() => {
-            const container = document.getElementById('myScrollSlider')
-
-            if (container) {
-              if (container.scrollHeight > container.clientHeight) {
-                container.scrollTop -= 200
-              } else {
-                container.scrollLeft -= 200
-              }
-            }
-          }}
+          onClick={() => moveScroll(elementsRef.current, -200)}
         />
       )}
-      <div id="myScrollSlider" data-carousel-track>
+      <div data-carousel-track ref={elementsRef}>
         {elements.map((el, idx) => {
           return <div key={idx}>{el}</div>
         })}
@@ -52,17 +50,7 @@ function ImageGallerySelector({
         <IconButton
           aria-label="forward slide image selector"
           icon={<Icon name="ArrowLeft" width={24} height={24} />}
-          onClick={() => {
-            const container = document.getElementById('myScrollSlider')
-
-            if (container) {
-              if (container?.scrollHeight > container?.clientHeight) {
-                container.scrollTop += 200
-              } else {
-                container.scrollLeft += 200
-              }
-            }
-          }}
+          onClick={() => moveScroll(elementsRef.current, +200)}
         />
       )}
     </section>

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -1,8 +1,7 @@
-import { IconButton, useSlider } from '@faststore/ui'
 import { Children } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
-
-import { BackwardArrowIcon, ForwardArrowIcon } from './Icons'
+import { IconButton } from '@faststore/ui'
+import Icon from 'src/components/ui/Icon'
 
 import './image-gallery-selector.scss'
 
@@ -30,7 +29,7 @@ function ImageGallerySelector({
       {elementCount > itemsPerPage && (
         <IconButton
           aria-label="backward slide image selector"
-          icon={<BackwardArrowIcon color="#323845" />}
+          icon={<Icon name="ArrowLeft" />}
           onClick={() => {
             const container = document.getElementById('myScrollSlider')
 
@@ -52,7 +51,7 @@ function ImageGallerySelector({
       {elementCount > itemsPerPage && (
         <IconButton
           aria-label="forward slide image selector"
-          icon={<ForwardArrowIcon color="#323845" />}
+          icon={<Icon name="ArrowRight" />}
           onClick={() => {
             const container = document.getElementById('myScrollSlider')
 

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -28,7 +28,6 @@ function getTransformValue(
 function ImageGallerySelector({
   itemsPerPage,
   children,
-  ...otherProps
 }: PropsWithChildren<Props>) {
   const elements = Children.toArray(children)
   const elementCount = elements.length
@@ -60,53 +59,52 @@ function ImageGallerySelector({
           slide('previous', sliderDispatch)
         }}
       />
-      <div {...otherProps} {...handlers}>
-        <div
-          data-carousel-track
-          style={{
-            display: 'flex',
-            transition: sliderState.sliding ? `transform 400ms` : undefined,
-            width: `${(elementCount * 100) / itemsPerPage}%`,
-            transform: `translate3d(${getTransformValue(
-              elementCount,
-              sliderState.currentPage,
-              itemsPerPage
-            )}%, 0, 0)`,
-          }}
-          onTransitionEnd={() => {
+      <div
+        data-carousel-track
+        style={{
+          display: 'flex',
+          transition: sliderState.sliding ? `transform 400ms` : undefined,
+          width: `${(elementCount * 100) / itemsPerPage}%`,
+          transform: `translate3d(${getTransformValue(
+            elementCount,
+            sliderState.currentPage,
+            itemsPerPage
+          )}%, 0, 0)`,
+        }}
+        onTransitionEnd={() => {
+          sliderDispatch({
+            type: 'STOP_SLIDE',
+          })
+
+          if (sliderState.currentItem >= elementCount) {
             sliderDispatch({
-              type: 'STOP_SLIDE',
+              type: 'GO_TO_PAGE',
+              payload: {
+                pageIndex: 0,
+                shouldSlide: false,
+              },
             })
+          }
 
-            if (sliderState.currentItem >= elementCount) {
-              sliderDispatch({
-                type: 'GO_TO_PAGE',
-                payload: {
-                  pageIndex: 0,
-                  shouldSlide: false,
-                },
-              })
-            }
-
-            if (sliderState.currentItem < 0) {
-              sliderDispatch({
-                type: 'GO_TO_PAGE',
-                payload: {
-                  pageIndex: sliderState.totalPages - 1,
-                  shouldSlide: false,
-                },
-              })
-            }
-          }}
-        >
-          {elements.map((el, idx) => {
-            return (
-              <div key={idx} style={{ width: `${100 / elementCount}%` }}>
-                <div>{el}</div>
-              </div>
-            )
-          })}
-        </div>
+          if (sliderState.currentItem < 0) {
+            sliderDispatch({
+              type: 'GO_TO_PAGE',
+              payload: {
+                pageIndex: sliderState.totalPages - 1,
+                shouldSlide: false,
+              },
+            })
+          }
+        }}
+        {...handlers}
+      >
+        {elements.map((el, idx) => {
+          return (
+            <div data-image-gallery-selector-thumb-image key={idx}>
+              {el}
+            </div>
+          )
+        })}
       </div>
       <IconButton
         aria-label="forward slide image selector"

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -54,8 +54,8 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
                 src={image.url}
                 alt={image.alternateName}
                 loading={idx === 0 ? 'eager' : 'lazy'}
-                width={250}
-                height={250}
+                width={112}
+                height={112}
               />
             </Button>
           )

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -56,7 +56,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
               data-thumbnail-button={
                 idx === currentImageIdx ? 'selected' : 'true'
               }
-              aria-label={`Load ${image.alternateName} - Image ${idx + 1} of ${
+              aria-label={`${image.alternateName} - Image ${idx + 1} of ${
                 images.length
               }`}
               onClick={() => onSelect(idx)}

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -9,9 +9,9 @@
   > [data-store-button] {
     position: absolute;
     z-index: 1;
-    flex-shrink: 0;
     background: linear-gradient(90deg, #ffffff 55.67%, rgb(255 255 255 / 0%) 88.53%);
     background-color: transparent;
+    border: none;
 
     span {
       padding: var(--fs-spacing-1);
@@ -61,6 +61,8 @@
     scroll-behavior: smooth;
 
     [data-store-button] {
+      flex-shrink: 0;
+      width: rem(56px);
       padding: 0;
       overflow: hidden;
       background-color: transparent;
@@ -70,8 +72,12 @@
       &[data-thumbnail-button="selected"] {
         @include focus-ring;
 
-        border-color: var(--color-border-input-selected);
+        border-color: var(--fs-border-color-default-active);
         border-width: var(--fs-border-color-default);
+      }
+
+      @include media(">=notebook") {
+        width: rem(72px);
       }
     }
 
@@ -79,16 +85,7 @@
       flex-direction: column;
       row-gap: var(--fs-spacing-2);
       padding: var(--fs-spacing-4) var(--fs-spacing-0);
-      overflow-y: scroll;
-    }
-  }
-
-  [data-store-image] {
-    width: rem(56px);
-    transform: translate3d(0, 0, 0);
-
-    @include media(">=notebook") {
-      width: rem(72px);
+      overflow-y: hidden;
     }
   }
 }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -71,14 +71,25 @@
       padding: 0;
       overflow: hidden;
       background-color: transparent;
-      border-color: transparent;
+      border: var(--fs-border-width-thick) solid transparent;
       border-radius: var(--fs-border-radius-default);
+      transition: all var(--fs-transition-timing) var(--fs-transition-function);
+
+      &:hover:not([data-thumbnail-button="selected"]) {
+        border-color: var(--fs-border-color-default-active);
+      }
 
       &[data-thumbnail-button="selected"] {
-        @include focus-ring;
-
-        border-color: var(--fs-color-primary-bkg-active);
+        border-color: var(--fs-border-color-default-active);
+        box-shadow: 0 0 0 var(--fs-border-width-thickest) var(--fs-color-focus-ring-outline);
       }
+
+      [data-store-image] {
+        border: var(--fs-border-width-thick) solid var(--fs-color-body-bkg);
+        border-radius: var(--fs-border-radius-default);
+      }
+
+      @include focus-ring-visible;
 
       @include media(">=notebook") {
         width: rem(72px);

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -5,6 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  max-height: rem(450px);
 
   > [data-store-button] {
     position: absolute;

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-[data-image-gallery-selector] {
+[data-fs-image-gallery-selector] {
   position: relative;
   display: flex;
   align-items: center;
@@ -53,7 +53,7 @@
     justify-content: space-between;
   }
 
-  [data-carousel-track] {
+  [data-fs-image-gallery-selector-elements] {
     display: flex;
     column-gap: var(--fs-spacing-1);
     padding: var(--fs-spacing-0) var(--fs-spacing-5);

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -44,6 +44,7 @@
 
     @include media(">=notebook") {
       flex-direction: column;
+      padding: 0 var(--space-0);
       overflow-y: scroll;
       row-gap: var(--space-2);
     }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -9,11 +9,13 @@
   > [data-store-button] {
     position: absolute;
     z-index: 1;
-    background: linear-gradient(90deg, #ffffff 55.67%, rgb(255 255 255 / 0%) 88.53%);
+    background: linear-gradient(90deg, var(--fs-color-body-bkg) 55%, transparent);
     background-color: transparent;
     border: none;
 
     span {
+      display: flex;
+      height: fit-content;
       padding: var(--fs-spacing-1);
       background-color: var(--fs-control-bkg-default);
       border-radius: var(--fs-border-radius-circle);
@@ -34,8 +36,10 @@
     }
 
     @include media(">=notebook") {
+      display: flex;
+      justify-content: center;
       width: 100%;
-      background: linear-gradient(180deg, #ffffff 55.67%, rgb(255 255 255 / 0%) 88.53%);
+      background: linear-gradient(180deg, var(--fs-color-body-bkg) 55%, transparent);
 
       span {
         transform: rotate(90deg);

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -7,9 +7,17 @@
 
   > [data-store-button] {
     z-index: 9999;
-    background-color: var(--bg-neutral);
+    background-color: var(--bg-neutral-lightest);
     border-radius: var(--border-radius-circle);
     box-shadow: var(--box-shadow);
+  }
+
+  @include media(">=notebook") {
+    flex-direction: column;
+
+    [data-store-icon] {
+      transform: rotate(90deg);
+    }
   }
 
   [data-carousel-track] {
@@ -22,11 +30,20 @@
       padding: 0;
       border: 0;
     }
+
+    @include media(">=notebook") {
+      flex-direction: column;
+      row-gap: var(--space-2);
+    }
   }
 
   [data-gatsby-image-wrapper] {
     width: rem(56px);
     border-radius: var(--border-radius-default);
     transform: translate3d(0, 0, 0);
+
+    @include media(">=notebook") {
+      width: rem(72px);
+    }
   }
 }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -61,7 +61,7 @@
   [data-fs-image-gallery-selector-elements] {
     display: flex;
     column-gap: var(--fs-spacing-1);
-    padding: var(--fs-spacing-0) var(--fs-spacing-5);
+    padding: var(--fs-spacing-0) var(--fs-spacing-6);
     overflow-x: auto;
     scroll-behavior: smooth;
 
@@ -99,7 +99,7 @@
     @include media(">=notebook") {
       flex-direction: column;
       row-gap: var(--fs-spacing-2);
-      padding: var(--fs-spacing-4) var(--fs-spacing-0);
+      padding: var(--fs-spacing-6) var(--fs-spacing-0);
       overflow-y: hidden;
     }
   }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -20,16 +20,11 @@
     }
   }
 
-  [data-carousel-track-container] {
-    width: 100%;
-    overflow: hidden;
-  }
-
   [data-carousel-track] {
     display: flex;
-    justify-content: space-between;
-    overflow: hidden;
-    transition: transform 400ms;
+    overflow: auto;
+    column-gap: var(--space-1);
+    scroll-behavior: smooth;
 
     [data-store-button] {
       background-color: transparent;

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -14,10 +14,10 @@
     background-color: transparent;
 
     span {
-      padding: var(--space-1);
-      background-color: var(--bg-neutral-lightest);
-      border-radius: var(--border-radius-circle);
-      box-shadow: var(--box-shadow);
+      padding: var(--fs-spacing-1);
+      background-color: var(--fs-control-bkg-default);
+      border-radius: var(--fs-border-radius-circle);
+      box-shadow: var(--fs-shadow);
     }
 
     @include media("<notebook") {
@@ -55,9 +55,9 @@
 
   [data-carousel-track] {
     display: flex;
-    padding: var(--space-0) var(--space-5);
+    column-gap: var(--fs-spacing-1);
+    padding: var(--fs-spacing-0) var(--fs-spacing-5);
     overflow-x: auto;
-    column-gap: var(--space-1);
     scroll-behavior: smooth;
 
     [data-store-button] {
@@ -65,25 +65,25 @@
       overflow: hidden;
       background-color: transparent;
       border: 2px solid transparent;
-      border-radius: var(--border-radius-default);
+      border-radius: var(--fs-border-radius-default);
 
       &[data-thumbnail-button="selected"] {
         @include focus-ring;
 
         border-color: var(--color-border-input-selected);
-        border-width: var(--border-width-1);
+        border-width: var(--fs-border-color-default);
       }
     }
 
     @include media(">=notebook") {
       flex-direction: column;
-      padding: var(--space-4) var(--space-0);
+      row-gap: var(--fs-spacing-2);
+      padding: var(--fs-spacing-4) var(--fs-spacing-0);
       overflow-y: scroll;
-      row-gap: var(--space-2);
     }
   }
 
-  [data-gatsby-image-wrapper] {
+  [data-store-image] {
     width: rem(56px);
     transform: translate3d(0, 0, 0);
 

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -64,20 +64,19 @@
     overflow-x: auto;
     scroll-behavior: smooth;
 
-    [data-store-button] {
+    > [data-store-button] {
       flex-shrink: 0;
       width: rem(56px);
       padding: 0;
       overflow: hidden;
       background-color: transparent;
-      border: 2px solid transparent;
+      border-color: transparent;
       border-radius: var(--fs-border-radius-default);
 
       &[data-thumbnail-button="selected"] {
         @include focus-ring;
 
-        border-color: var(--fs-border-color-default-active);
-        border-width: var(--fs-border-color-default);
+        border-color: var(--fs-color-primary-bkg-active);
       }
 
       @include media(">=notebook") {

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  max-height: rem(450px);
+  max-height: rem(550px);
 
   > [data-store-button] {
     position: absolute;

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -3,10 +3,9 @@
 [data-image-gallery-selector] {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
 
   > [data-store-button] {
-    z-index: 9999;
     background-color: var(--bg-neutral-lightest);
     border-radius: var(--border-radius-circle);
     box-shadow: var(--box-shadow);
@@ -14,20 +13,26 @@
 
   @include media(">=notebook") {
     flex-direction: column;
+    justify-content: space-between;
 
     [data-store-icon] {
       transform: rotate(90deg);
     }
   }
 
+  [data-carousel-track-container] {
+    width: 100%;
+    overflow: hidden;
+  }
+
   [data-carousel-track] {
-    // min-width: 100%;
     display: flex;
-    justify-content: center;
-    column-gap: var(--space-2);
+    justify-content: space-between;
+    overflow: hidden;
+    transition: transform 400ms;
 
     [data-store-button] {
-      padding: 0;
+      background-color: transparent;
       border: 0;
     }
 

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -1,10 +1,23 @@
+@import "src/styles/scaffold";
+
 [data-image-gallery-selector] {
   display: flex;
   align-items: center;
   justify-content: space-around;
 
-  > div {
+  [data-carousel-track] {
     display: flex;
     justify-content: space-around;
+  }
+
+  [data-store-button] {
+    padding: 0;
+    border: 0;
+  }
+
+  [data-gatsby-image-wrapper] {
+    width: rem(56px);
+    border-radius: var(--border-radius-default);
+    transform: translate3d(0, 0, 0);
   }
 }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -1,0 +1,10 @@
+[data-image-gallery-selector] {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+
+  > div {
+    display: flex;
+    justify-content: space-around;
+  }
+}

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -1,28 +1,61 @@
 @import "src/styles/scaffold";
 
 [data-image-gallery-selector] {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
 
   > [data-store-button] {
-    background-color: var(--bg-neutral-lightest);
-    border-radius: var(--border-radius-circle);
-    box-shadow: var(--box-shadow);
+    position: absolute;
+    z-index: 1;
+    flex-shrink: 0;
+    background: linear-gradient(90deg, #ffffff 55.67%, rgb(255 255 255 / 0%) 88.53%);
+    background-color: transparent;
+
+    span {
+      padding: var(--space-1);
+      background-color: var(--bg-neutral-lightest);
+      border-radius: var(--border-radius-circle);
+      box-shadow: var(--box-shadow);
+    }
+
+    @include media("<notebook") {
+      height: 100%;
+
+      &:first-child {
+        left: 0;
+      }
+
+      &:last-child {
+        right: 0;
+        transform: scaleX(-1);
+      }
+    }
+
+    @include media(">=notebook") {
+      width: 100%;
+      background: linear-gradient(180deg, #ffffff 55.67%, rgb(255 255 255 / 0%) 88.53%);
+
+      span {
+        transform: rotate(90deg);
+      }
+
+      &:last-child {
+        bottom: 0;
+        transform: scaleY(-1);
+      }
+    }
   }
 
   @include media(">=notebook") {
     flex-direction: column;
     justify-content: space-between;
-
-    [data-store-icon] {
-      transform: rotate(90deg);
-    }
   }
 
   [data-carousel-track] {
     display: flex;
-    padding: var(--space-0) 0;
+    padding: var(--space-0) var(--space-5);
     overflow-x: auto;
     column-gap: var(--space-1);
     scroll-behavior: smooth;
@@ -44,7 +77,7 @@
 
     @include media(">=notebook") {
       flex-direction: column;
-      padding: 0 var(--space-0);
+      padding: var(--space-4) var(--space-0);
       overflow-y: scroll;
       row-gap: var(--space-2);
     }

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -22,24 +22,35 @@
 
   [data-carousel-track] {
     display: flex;
-    overflow: auto;
+    padding: var(--space-0) 0;
+    overflow-x: auto;
     column-gap: var(--space-1);
     scroll-behavior: smooth;
 
     [data-store-button] {
+      padding: 0;
+      overflow: hidden;
       background-color: transparent;
-      border: 0;
+      border: 2px solid transparent;
+      border-radius: var(--border-radius-default);
+
+      &[data-thumbnail-button="selected"] {
+        @include focus-ring;
+
+        border-color: var(--color-border-input-selected);
+        border-width: var(--border-width-1);
+      }
     }
 
     @include media(">=notebook") {
       flex-direction: column;
+      overflow-y: scroll;
       row-gap: var(--space-2);
     }
   }
 
   [data-gatsby-image-wrapper] {
     width: rem(56px);
-    border-radius: var(--border-radius-default);
     transform: translate3d(0, 0, 0);
 
     @include media(">=notebook") {

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  max-height: rem(550px);
+  max-height: rem(530px);
 
   > [data-store-button] {
     position: absolute;

--- a/src/components/ui/ImageGallery/image-gallery-selector.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.scss
@@ -3,16 +3,25 @@
 [data-image-gallery-selector] {
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
 
-  [data-carousel-track] {
-    display: flex;
-    justify-content: space-around;
+  > [data-store-button] {
+    z-index: 9999;
+    background-color: var(--bg-neutral);
+    border-radius: var(--border-radius-circle);
+    box-shadow: var(--box-shadow);
   }
 
-  [data-store-button] {
-    padding: 0;
-    border: 0;
+  [data-carousel-track] {
+    // min-width: 100%;
+    display: flex;
+    justify-content: center;
+    column-gap: var(--space-2);
+
+    [data-store-button] {
+      padding: 0;
+      border: 0;
+    }
   }
 
   [data-gatsby-image-wrapper] {

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -8,8 +8,6 @@
   width: calc(100% + (2 * var(--fs-grid-padding)));
   row-gap: var(--space-2);
 
-  // max-height: rem(450px);
-
   @include media(">=notebook") {
     display: flex;
     flex-direction: row-reverse;
@@ -32,4 +30,15 @@
   }
 
   @include media(">=notebook") { grid-column: span 8; }
+}
+
+[data-image-gallery="has-selector"] {
+  @include media(">notebook") {
+    // TODO: Define this aspect ratio as token so we can apply to differnt ratios of images;
+    aspect-ratio: 4.57/3;
+
+    // This max-height is defined as a fallback for browsers
+    // that does not support the aspect-ratio property
+    max-height: rem(600px);
+  }
 }

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   width: calc(100% + (2 * var(--fs-grid-padding)));
-  row-gap: var(--space-1);
+  row-gap: var(--space-2);
 
   @include media(">=notebook") {
     display: flex;

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -7,6 +7,7 @@
   flex-direction: column;
   width: calc(100% + (2 * var(--fs-grid-padding)));
   row-gap: var(--space-2);
+  max-height: rem(450px);
 
   @include media(">=notebook") {
     display: flex;

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -11,6 +11,7 @@
   @include media(">=notebook") {
     display: flex;
     flex-direction: row-reverse;
+    column-gap: var(--space-3);
   }
 
   [data-gatsby-image-wrapper] {

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -14,10 +14,9 @@
     column-gap: var(--fs-spacing-3);
   }
 
-  [data-store-image] {
+  > [data-store-image] {
     @include media(">=tablet") {
       border-radius: var(--fs-border-radius-default);
-      transform: translate3d(0, 0, 0);
     }
   }
 
@@ -38,7 +37,7 @@
     // that does not support the aspect-ratio property
     max-height: rem(600px);
 
-    // TODO: Define this aspect ratio as token so we can apply to differnt ratios of images;
+    // TODO: Define this aspect ratio as token
     aspect-ratio: 4.57/3;
   }
 }

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -1,0 +1,32 @@
+@import "src/styles/scaffold";
+
+[data-image-gallery] {
+  position: relative;
+  left: calc(-1 * var(--fs-grid-padding));
+  display: flex;
+  flex-direction: column;
+  width: calc(100% + (2 * var(--fs-grid-padding)));
+  row-gap: var(--space-1);
+
+  @include media(">=notebook") {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  [data-gatsby-image-wrapper] {
+    @include media(">=tablet") {
+      border-radius: var(--fs-border-radius-default);
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  @include media(">=tablet") {
+    left: 0;
+    grid-row: 1 / span 2;
+    grid-column: span 7;
+    width: 100%;
+    margin-bottom: var(--fs-spacing-7);
+  }
+
+  @include media(">=notebook") { grid-column: span 8; }
+}

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -30,14 +30,3 @@
 
   @include media(">=notebook") { grid-column: span 8; }
 }
-
-[data-fs-image-gallery="has-selector"] {
-  @include media(">notebook") {
-    // This max-height is defined as a fallback for browsers
-    // that does not support the aspect-ratio property
-    max-height: rem(600px);
-
-    // TODO: Define this aspect ratio as token
-    aspect-ratio: 4.57/3;
-  }
-}

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -5,16 +5,16 @@
   left: calc(-1 * var(--fs-grid-padding));
   display: flex;
   flex-direction: column;
+  row-gap: var(--fs-spacing-2);
   width: calc(100% + (2 * var(--fs-grid-padding)));
-  row-gap: var(--space-2);
 
   @include media(">=notebook") {
     display: flex;
     flex-direction: row-reverse;
-    column-gap: var(--space-3);
+    column-gap: var(--fs-spacing-3);
   }
 
-  [data-gatsby-image-wrapper] {
+  [data-store-image] {
     @include media(">=tablet") {
       border-radius: var(--fs-border-radius-default);
       transform: translate3d(0, 0, 0);
@@ -34,11 +34,11 @@
 
 [data-image-gallery="has-selector"] {
   @include media(">notebook") {
-    // TODO: Define this aspect ratio as token so we can apply to differnt ratios of images;
-    aspect-ratio: 4.57/3;
 
     // This max-height is defined as a fallback for browsers
     // that does not support the aspect-ratio property
     max-height: rem(600px);
+    // TODO: Define this aspect ratio as token so we can apply to differnt ratios of images;
+    aspect-ratio: 4.57/3;
   }
 }

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-[data-image-gallery] {
+[data-fs-image-gallery] {
   position: relative;
   left: calc(-1 * var(--fs-grid-padding));
   display: flex;
@@ -32,12 +32,12 @@
   @include media(">=notebook") { grid-column: span 8; }
 }
 
-[data-image-gallery="has-selector"] {
+[data-fs-image-gallery="has-selector"] {
   @include media(">notebook") {
-
     // This max-height is defined as a fallback for browsers
     // that does not support the aspect-ratio property
     max-height: rem(600px);
+
     // TODO: Define this aspect ratio as token so we can apply to differnt ratios of images;
     aspect-ratio: 4.57/3;
   }

--- a/src/components/ui/ImageGallery/image-gallery.scss
+++ b/src/components/ui/ImageGallery/image-gallery.scss
@@ -7,7 +7,8 @@
   flex-direction: column;
   width: calc(100% + (2 * var(--fs-grid-padding)));
   row-gap: var(--space-2);
-  max-height: rem(450px);
+
+  // max-height: rem(450px);
 
   @include media(">=notebook") {
     display: flex;

--- a/src/styles/pages/pdp.scss
+++ b/src/styles/pages/pdp.scss
@@ -15,6 +15,8 @@
 // UI
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
 @import "src/components/ui/Image/image.scss";
+@import "src/components/ui/ImageGallery/image-gallery.scss";
+@import "src/components/ui/ImageGallery/image-gallery-selector.scss";
 @import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
 @import "src/components/ui/QuantitySelector/quantity-selector.scss";

--- a/store.config.js
+++ b/store.config.js
@@ -24,7 +24,7 @@ module.exports = {
     server: process.env.BASE_SITE_URL || 'http://localhost:9000',
     pages: {
       home: '/',
-      pdp: '/apple-magic-mouse-99988212/p',
+      pdp: '/awesome-wooden-bike-sleek-47501742/p',
       collection: '/office',
     },
   },
@@ -33,7 +33,7 @@ module.exports = {
   cypress: {
     pages: {
       home: '/',
-      pdp: '/apple-magic-mouse-99988212/p',
+      pdp: '/awesome-wooden-bike-sleek-47501742/p',
       collection: '/office',
       collection_filtered:
         '/office/?category-1=office&marca=acer&facets=category-1%2Cmarca',


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR addresses the tasks of [Style](https://vtex-dev.atlassian.net/browse/FSSS-58) and [Integrate](https://vtex-dev.atlassian.net/browse/FSSS-55) the [ImageGallery Component](https://github.com/vtex-sites/base.store/blob/master/src/components/ui/ImageGallery/ImageGallery.tsx) to the Product Display Page, as shown in this [figma file](https://www.figma.com/file/zHMOtOPduiM0hNNcg21iR1/Handoff-PDP-v0.1?node-id=18%3A33225).

There are still some minor adjustments to make. I've added them to the checklist below and I may tackle it in this PR or in future PRs so we can merge this one.

## How does it work?

I've changed the ImageGallery to not use the [Faststore's useSlider](https://github.com/vtex/faststore/blob/master/packages/ui/src/hooks/useSlider/useSlider.ts) component in favor of an approach using the default browser scroll, with a button controlling it through javascript.

The results are as follows:
|State |Desktop  | Mobile|
--- | --- | ---|
|1 item|![image](https://user-images.githubusercontent.com/8497187/162503014-76ce221a-820c-4903-96d1-0d419d831fc4.png)|![image](https://user-images.githubusercontent.com/8497187/162502952-7d6697c7-415a-499f-92b0-63bb3572a79f.png)|
|> 1 item|![image](https://user-images.githubusercontent.com/8497187/162503249-6f1ccf14-befb-4634-b4b7-3b2b7a93c6d7.png)|![image](https://user-images.githubusercontent.com/8497187/162503315-7f472fd8-9b02-45fb-b552-9d3cea17a034.png)|
|with scroll|![image](https://user-images.githubusercontent.com/8497187/162508181-7239cb32-8522-43e0-a02d-0553feed4cf3.png)|![image](https://user-images.githubusercontent.com/8497187/16250
|gif|![ezgif com-gif-maker(2)](https://user-images.githubusercontent.com/8497187/162510633-5659d2d3-07fb-4e74-9e49-4407519674f1.gif)|![ezgif com-gif-maker(1)](https://user-images.githubusercontent.com/8497187/162510404-a6484274-fe06-4d71-b230-e1da83d64a85.gif)|

## How to test it?

Go to the preview link and test the PDP of products with different amounts of product images:
- [with only 1 image](https://preview-409--base.preview.vtex.app/aedle-vk1-headphone-99988211/p)
- [with more than 1 image, but without scroll](https://preview-409--base.preview.vtex.app/awesome-plastic-bacon-9938908/p)
- [with scroll](https://preview-409--base.preview.vtex.app/awesome-wooden-bike-sleek-47501742/p)

Remember to test it for desktop and mobile. Try around with the scroll, use it with the buttons or with the scroll bar.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
- [x] Remove padding of selector items when there is no scroll [Jira task created](https://vtex-dev.atlassian.net/browse/FSSS-280)
- [x] Display/hide arrow buttons according to scroll position [Jira task created](https://vtex-dev.atlassian.net/browse/FSSS-280)
- [x] Uses aspect ratio instead of fixed height to define max height of main image
- [x] Adding Zoom tool [Jira task created](https://vtex-dev.atlassian.net/browse/FSSS-281)
- [x] Themify component [Jira task created](https://vtex-dev.atlassian.net/browse/FSSS-282)

Thanks to @renatamottam @saranicoly @heitorado @filipeafns and @lucasfp13 for all the help
