### PR TITLE
chore: Reduce PLP blocking time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New folder `styles/global` containing all global styles.
 
 ### Changed
-
+- Split `ProductGallery` rendering component into multiple tasks
 - Move inline styles to external stylesheet to improve TBT
 - Changed ProductGallery and EmptyGallery styles to make the search results page
 - Moved all icons to use Icon component

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -47,13 +47,13 @@ function GalleryPage({
     [productList]
   )
 
-  const productsSponsored = products?.slice(0, 2)
-
-  const middleItemIndex = Math.ceil(itemsPerPage / 2)
-
   if (display === false || products == null) {
     return null
   }
+
+  const productsSponsored = products?.slice(0, 2)
+
+  const middleItemIndex = Math.ceil(itemsPerPage / 2)
 
   const shouldDisplaySponsoredProducts =
     showSponsoredProducts &&


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds a crazy hack to decrease PLP blocking time

## How does it work?
ProductGallery component has a huge blocking time because it renders lots of things. This PR tries to break down the order these things gets rendered so we get a small blocking time footprint.

The tactics is to split priority components, like Filters and GalleryPage components from non priority ones, like next/prev links and products preload. To achieve this, I created a hook that delays pagination info, forcing pagination dependent components to render on the next frame.

The images below is the before/after flamegraph of ProductGallery component:
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/1753396/160128032-4aba7f88-3bc4-47cf-92c5-c2b07731a9c3.png">
<img width="1217" alt="image" src="https://user-images.githubusercontent.com/1753396/160127888-31c97818-42e8-4238-a1d8-211b5da9ee1d.png">

As you can see, the mega task was split smaller ones, decreasing tbt a little bit

## Checklist
- [x] CHANGELOG entry added
