### PR TITLE
chore: Reduce PLP blocking time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Add preloadQuery function
 - Add hideUnavailableItems at store.config
 - Sections component with `content-visibility: auto`
 - Webpack Bundle analyzer

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -120,8 +120,8 @@ module.exports = {
         getSchema,
         getContextFactory,
         // Source less products is development for better DX
-        maxNumProducts: 10, // isProduction ? 2500 : 100,
-        maxNumCollections: 10, // isProduction ? 2500 : 100,
+        maxNumProducts: isProduction ? 2500 : 100,
+        maxNumCollections: isProduction ? 2500 : 100,
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -120,8 +120,8 @@ module.exports = {
         getSchema,
         getContextFactory,
         // Source less products is development for better DX
-        maxNumProducts: isProduction ? 2500 : 100,
-        maxNumCollections: isProduction ? 2500 : 100,
+        maxNumProducts: 10, // isProduction ? 2500 : 100,
+        maxNumCollections: 10, // isProduction ? 2500 : 100,
       },
     },
     {

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -93,7 +93,7 @@ function ProductGallery({ title, searchTerm }: Props) {
           {/* Add link to previous page. This helps on SEO */}
           {prev !== false && (
             <div className="product-listing__pagination product-listing__pagination--top">
-              <GatsbySeo linkTags={[{ rel: 'prev', href: prev.link }]} />
+              <GatsbySeo defer linkTags={[{ rel: 'prev', href: prev.link }]} />
               <ButtonLink
                 onClick={(e) => {
                   e.currentTarget.blur()
@@ -133,7 +133,7 @@ function ProductGallery({ title, searchTerm }: Props) {
           {/* Add link to next page. This helps on SEO */}
           {next !== false && (
             <div className="product-listing__pagination product-listing__pagination--bottom">
-              <GatsbySeo linkTags={[{ rel: 'next', href: next.link }]} />
+              <GatsbySeo defer linkTags={[{ rel: 'next', href: next.link }]} />
               <ButtonLink
                 data-testid="show-more"
                 onClick={(e) => {

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -14,6 +14,7 @@ import Section from '../Section'
 import EmptyGallery from './EmptyGallery'
 import { useDelayedFacets } from './useDelayedFacets'
 import { useGalleryQuery } from './useGalleryQuery'
+import { usePreloadPageProducts } from './usePageProducts'
 
 const GalleryPage = lazy(() => import('./ProductGalleryPage'))
 const GalleryPageSkeleton = <ProductGridSkeleton loading />
@@ -25,11 +26,15 @@ interface Props {
 
 function ProductGallery({ title, searchTerm }: Props) {
   const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false)
-  const { pages, state: searchState, addNextPage, addPrevPage } = useSearch()
+  const { pages, addNextPage, addPrevPage, state: searchState } = useSearch()
+
   const { data } = useGalleryQuery()
   const facets = useDelayedFacets(data)
   const totalCount = data?.search.products.pageInfo.totalCount ?? 0
   const { next, prev } = usePagination(totalCount)
+
+  usePreloadPageProducts(prev ? prev.cursor : null)
+  usePreloadPageProducts(next ? next.cursor : null)
 
   if (data && totalCount === 0) {
     return (
@@ -123,28 +128,6 @@ function ProductGallery({ title, searchTerm }: Props) {
             </Suspense>
           ) : (
             GalleryPageSkeleton
-          )}
-
-          {/* Prefetch Previous and Next pages */}
-          {prev !== false && (
-            <Suspense fallback={null}>
-              <GalleryPage
-                showSponsoredProducts={false}
-                page={prev.cursor}
-                display={false}
-                title={title}
-              />
-            </Suspense>
-          )}
-          {next !== false && (
-            <Suspense fallback={null}>
-              <GalleryPage
-                showSponsoredProducts={false}
-                page={next.cursor}
-                display={false}
-                title={title}
-              />
-            </Suspense>
           )}
 
           {/* Add link to next page. This helps on SEO */}

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -14,7 +14,7 @@ import Section from '../Section'
 import EmptyGallery from './EmptyGallery'
 import { useDelayedFacets } from './useDelayedFacets'
 import { useGalleryQuery } from './useGalleryQuery'
-import { usePreloadPageProducts } from './usePageProducts'
+import { usePrefetchPageProducts } from './usePageProducts'
 
 const GalleryPage = lazy(() => import('./ProductGalleryPage'))
 const GalleryPageSkeleton = <ProductGridSkeleton loading />
@@ -33,8 +33,8 @@ function ProductGallery({ title, searchTerm }: Props) {
   const totalCount = data?.search.products.pageInfo.totalCount ?? 0
   const { next, prev } = usePagination(totalCount)
 
-  usePreloadPageProducts(prev ? prev.cursor : null)
-  usePreloadPageProducts(next ? next.cursor : null)
+  usePrefetchPageProducts(prev ? prev.cursor : null)
+  usePrefetchPageProducts(next ? next.cursor : null)
 
   if (data && totalCount === 0) {
     return (

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -24,13 +24,13 @@ function GalleryPage({
   const products = usePageProducts(page, fallbackData)
   const { itemsPerPage } = useSearch()
 
-  const productsSponsored = products?.slice(0, 2)
-
-  const middleItemIndex = Math.ceil(itemsPerPage / 2)
-
   if (products == null) {
     return null
   }
+
+  const productsSponsored = products?.slice(0, 2)
+
+  const middleItemIndex = Math.ceil(itemsPerPage / 2)
 
   const shouldDisplaySponsoredProducts =
     showSponsoredProducts &&

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -1,16 +1,15 @@
 import { useSearch } from '@faststore/sdk'
-import React, { useMemo } from 'react'
+import React from 'react'
 import ProductGrid from 'src/components/product/ProductGrid'
-import { useProductsQuery } from 'src/sdk/product/useProductsQuery'
 import Sentinel from 'src/sdk/search/Sentinel'
 import type { ProductsQueryQuery } from '@generated/graphql'
 
 import ProductTiles from '../ProductTiles'
+import { usePageProducts } from './usePageProducts'
 
 /* If showSponsoredProducts is true, a ProductTiles will be displayed in between two blocks of ProductGrid on the page 0 */
 interface Props {
   page: number
-  display?: boolean
   fallbackData?: ProductsQueryQuery
   title: string
   showSponsoredProducts?: boolean
@@ -18,40 +17,18 @@ interface Props {
 
 function GalleryPage({
   page,
-  display,
   title,
   fallbackData,
   showSponsoredProducts = true,
 }: Props) {
-  const {
-    itemsPerPage,
-    state: { sort, term, selectedFacets },
-  } = useSearch()
-
-  const productList = useProductsQuery(
-    {
-      first: itemsPerPage,
-      after: (itemsPerPage * page).toString(),
-      sort,
-      term: term ?? '',
-      selectedFacets,
-    },
-    {
-      fallbackData,
-      revalidateOnMount: fallbackData == null,
-    }
-  )
-
-  const products = useMemo(
-    () => productList?.edges.map((edge) => edge.node),
-    [productList]
-  )
+  const products = usePageProducts(page, fallbackData)
+  const { itemsPerPage } = useSearch()
 
   const productsSponsored = products?.slice(0, 2)
 
   const middleItemIndex = Math.ceil(itemsPerPage / 2)
 
-  if (display === false || products == null) {
+  if (products == null) {
     return null
   }
 

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -28,15 +28,14 @@ function GalleryPage({
     return null
   }
 
-  const productsSponsored = products?.slice(0, 2)
+  const productsSponsored = showSponsoredProducts
+    ? products.slice(0, 2)
+    : undefined
 
   const middleItemIndex = Math.ceil(itemsPerPage / 2)
 
   const shouldDisplaySponsoredProducts =
-    showSponsoredProducts &&
-    page === 0 &&
-    productsSponsored !== undefined &&
-    productsSponsored.length > 1
+    page === 0 && productsSponsored && productsSponsored.length > 1
 
   return (
     <>

--- a/src/components/sections/ProductGallery/usePageProducts.ts
+++ b/src/components/sections/ProductGallery/usePageProducts.ts
@@ -1,0 +1,57 @@
+import { useSearch } from '@faststore/sdk'
+import { useEffect, useMemo } from 'react'
+import {
+  prefetchProductsQuery,
+  useProductsQuery,
+} from 'src/sdk/product/useProductsQuery'
+import type { ProductsQueryQuery } from '@generated/graphql'
+
+export const usePreloadPageProducts = (page: number | null) => {
+  const {
+    itemsPerPage,
+    state: { sort, term, selectedFacets },
+  } = useSearch()
+
+  useEffect(() => {
+    if (page !== null) {
+      prefetchProductsQuery({
+        first: itemsPerPage,
+        after: (itemsPerPage * page).toString(),
+        sort,
+        term: term ?? '',
+        selectedFacets,
+      })
+    }
+  }, [itemsPerPage, page, selectedFacets, sort, term])
+}
+
+export const usePageProducts = (
+  page: number,
+  fallbackData?: ProductsQueryQuery
+) => {
+  const {
+    itemsPerPage,
+    state: { sort, term, selectedFacets },
+  } = useSearch()
+
+  const productList = useProductsQuery(
+    {
+      first: itemsPerPage,
+      after: (itemsPerPage * page).toString(),
+      sort,
+      term: term ?? '',
+      selectedFacets,
+    },
+    {
+      fallbackData,
+      revalidateOnMount: false,
+    }
+  )
+
+  const products = useMemo(
+    () => productList?.edges.map((edge) => edge.node),
+    [productList]
+  )
+
+  return products
+}

--- a/src/components/sections/ProductGallery/usePageProducts.ts
+++ b/src/components/sections/ProductGallery/usePageProducts.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/sdk/product/useProductsQuery'
 import type { ProductsQueryQuery } from '@generated/graphql'
 
-export const usePreloadPageProducts = (page: number | null) => {
+export const usePrefetchPageProducts = (page: number | null) => {
   const {
     itemsPerPage,
     state: { sort, term, selectedFacets },

--- a/src/sdk/graphql/prefetchQuery.ts
+++ b/src/sdk/graphql/prefetchQuery.ts
@@ -1,0 +1,16 @@
+import { mutate } from 'swr'
+
+import { request } from './request'
+import { getKey } from './useQuery'
+import type { RequestOptions } from './request'
+
+export const prefetchQuery = <Data, Variables = Record<string, unknown>>(
+  operationName: string,
+  variables: Variables,
+  options?: RequestOptions
+) => {
+  mutate(
+    getKey(operationName, variables),
+    request<Data, Variables>(operationName, variables, options)
+  )
+}

--- a/src/sdk/product/useProductsQuery.ts
+++ b/src/sdk/product/useProductsQuery.ts
@@ -4,6 +4,7 @@ import type {
   ProductsQueryQueryVariables,
 } from '@generated/graphql'
 
+import { prefetchQuery } from '../graphql/prefetchQuery'
 import { useQuery } from '../graphql/useQuery'
 import type { QueryOptions } from '../graphql/useQuery'
 
@@ -51,3 +52,8 @@ export const useProductsQuery = (
 
   return data?.search.products
 }
+
+export const prefetchProductsQuery = (
+  variables: ProductsQueryQueryVariables,
+  options?: QueryOptions
+) => prefetchQuery(query, variables, options)


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR improves PLP performance by reducing Total Blocking time

## How does it work?
`<ProductGalleryPage/>` component creates some decent amount of blocking time. This is mainly because it renders a list of `<ProductCards/>`, that sums up to a big TBT. Looking at the flame chart, however, I've noticed that some time of the task was being spend on preloading the next page on the pagination. 
This PR addresses this issue by creating a `preloadQuery` function and deferring the preload to a different task. This should reduce some blocking time of the PLP.

Below, you can see the before/after flame chart for the `<ProductGalleryPage/>` component. Notice how the highlighted  `anonymous` function disappears from one image to the other
<div style="display: flex">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1753396/161291924-5efc8157-86ef-4178-9db7-2bec94553a73.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1753396/161291962-d96ea626-a18b-499f-921e-22d5d93716f8.png">
</div>

## How to test it?
Make sure all pagination features are still working

## Checklist
- [x] CHANGELOG entry added
