### PR TITLE
Updates CHANGELOG to match base.store's March Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,94 +8,113 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add preloadQuery function
-- Add hideUnavailableItems at store.config
-- Sections component with `content-visibility: auto`
-- Webpack Bundle analyzer
-- `GatsbyLink` to `Link` ui component.
-- `Skeleton` loading components.
-- `SuggestionsTopSearch` component
-- `PostalCodeInput` component and `usePostalCode` hook.
-- `SuggestionProductCard` component.
-- `EmptyState` component.
-- `EmptyState` at the `ProductGallery` section.
-- `IconSVG` component to load SVG Icons.
-- `Suggestions` component.
-- `SearchHistory` component.
-- `Badge` interactive variation.
-- New folder `styles/global` containing all global styles.
-- New file `styles/global/tokens.scss` containing all global design tokens.
-- Session mutation when the user enters a new postal code.
-- Send channel string as search facet
+
+- Add preloadQuery function (#445)
+- New file `styles/global/tokens.scss` containing all global design tokens. (#442)
+- Send channel string as search facet (#428)
 
 ### Changed
-- Move ProductShelf and ProductTiles to the client side
-- Drop gatsby-plugin-image in favor of custom/simpler component
-- Replace `stylelint-config-rational-order` with `stylelint-config-recess-order`
-- Simplify filters component by using `useReducer` instead of multiple `useState`
-- Move inline styles to external stylesheet to improve TBT
-- Changed ProductGallery and EmptyGallery styles to make the search results page
-- Moved all icons to use Icon component
-- Moved common/IconsSVG to ui/Icons
-- Moved EmptyState from common to ui folder
-- Removed fit-in property from image component
-- Sections are now self-contained
-- Moves icons to `/static/icons` folder
-- Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder
-- Replaces `let` declarations for `useRef` for better React compatibility
-- Refactors cart sidebar
-- `BreadcrumbWrapper` from components/ui folder to `Breadcrumb` at components/sections
-- Replace relative stylesheets imports with absolute path
-- Moves some `Filter` component logic to the API
-- `Sort` and `Button Filter` (Mobile) `Skeleton's` loading criteria
-- Keep the latest `Filter` component state (Mobile)
-- Implements the expanded mode of `Searchbar` in mobile devices.
-- Updates Lighthouse and Cypress URL with valid product links
-- `Hero` image responsive sizes for mobile and desktop.
-- `Badge` variants names
-- `Tiles` and `Tile` to use semantic list elements.
-- `postalCode` from storage to Session context.
-- Updates all tokens naming and simplifies the global styles.
-- Changes `theme.scss` file to `global/tokens.scss`.
-- Applies new local tokens to `ProductCard`.
-- `OutOfStock` style and success message.
-- Apply new local tokens to `Button`
-- Gather all `Button` variants in the folder (`ButtonBuy`, `ButtonLink`, `ButtonIcon`, `ButtonSignIn`)
+
+- Move ProductShelf and ProductTiles to the client side (#431)
+- Drop gatsby-plugin-image in favor of custom/simpler component (#401)
+- Replace `stylelint-config-rational-order` with `stylelint-config-recess-order` (#415)
+- Simplify filters component by using `useReducer` instead of multiple `useState` (#422)
+- Applies new local tokens to `ProductCard`. (#425)
+- `OutOfStock` style and success message. (#399)
+- Apply new local tokens to `Button` (#442)
+- Gather all `Button` variants in the folder (`ButtonBuy`, `ButtonLink`, `ButtonIcon`, `ButtonSignIn`) (#442)
 
 ### Deprecated
 
-- useWindowDimensions hook
-
 ### Removed
-- Frontend computation in favor of backend processing
-- Removing hooks folder and migrating these hooks to sdk ou inline them on components
-- gatsby-plugin-offline due to CLS on recurrent users
-- useWindowDimensions hook
-- Removes unused `<FacetedFilter/>` component
-- Unnecessary map at hooks
-- API style redirects from `/_v/private/graphql` since they have no effect
-- Display box from `<ProductCard/>` component
-- `useTotalCount` hook
-- Phosphor-react library
-- `main::store::postalCode` value from storage.
 
 ### Fixed
-- CSS Warnings
-- Unnecessary app rerender after login feature
-- Fix typos found across the codebase
-- Fix border style for Product Card and its skeleton on mobile
-- The divisor for the `Breadcrumb` component not rendering valid HTML.
-- useBuyButton/useRemoveButton hooks with inconsistent typings/behaviors
-- React tree re-rendering
-- Footer rendering pipeline
-- Scroll lock when transitioning pages on mobile via `SlideOver` component navigation
-- Filter Button specificity on desktop
-- Filter facets are not being selected on mobile
-- `CartItem` image size and truncate long product's title
-- Entrusting the definition of the cursor property to the browser
-- Fix alert banner colors
+
+- CSS Warnings (#434)
+- Fix alert banner colors (#442)
 
 ### Security
+
+## [0.2.0] - 2022-04-01
+
+### Added
+
+- Add hideUnavailableItems at store.config (#400)
+- Sections component with `content-visibility: auto` (#368)
+- Webpack Bundle analyzer (#357)
+- `GatsbyLink` to `Link` ui component. (#329)
+- `Skeleton` loading components. (#317)
+- `SuggestionsTopSearch` component (#355)
+- `PostalCodeInput` component and `usePostalCode` hook. (#322)
+- `SuggestionProductCard` component. (#359)
+- `EmptyState` component. (#367)
+- `EmptyState` at the `ProductGallery` section. (#367)
+- `IconSVG` component to load SVG Icons. (#378)
+- `Suggestions` component. (#372)
+- `SearchHistory` component. (#391)
+- `Badge` interactive variation. (#396)
+- New folder `styles/global` containing all global styles. (#407)
+- Session mutation when the user enters a new postal code. (#392)
+
+### Changed
+
+- Move inline styles to external stylesheet to improve TBT (#408)
+- Changed ProductGallery and EmptyGallery styles to make the search results page (#387)
+- Moved all icons to use Icon component (#386)
+- Moved common/IconsSVG to ui/Icons (#386)
+- Moved EmptyState from common to ui folder (#386)
+- Removed fit-in property from image component (#375)
+- Sections are now self-contained (#371)
+- Moves icons to `/static/icons` folder (#357)
+- Replaces page type redirects, a.k.a. `/account`, `/login` to a corresponding file in `/pages` folder (#310)
+- Replaces `let` declarations for `useRef` for better React compatibility (#319)
+- Refactors cart sidebar (#325)
+- `BreadcrumbWrapper` from components/ui folder to `Breadcrumb` at components/sections (#326)
+- Replace relative stylesheets imports with absolute path (#349)
+- Moves some `Filter` component logic to the API (#321)
+- `Sort` and `Button Filter` (Mobile) `Skeleton's` loading criteria (#362)
+- Keep the latest `Filter` component state (Mobile) (#362)
+- Implements the expanded mode of `Searchbar` in mobile devices. (#369)
+- Updates Lighthouse and Cypress URL with valid product links (#369)
+- `Hero` image responsive sizes for mobile and desktop. (#363)
+- `Badge` variants names (#381)
+- `Tiles` and `Tile` to use semantic list elements. (#383)
+- `postalCode` from storage to Session context. (#388)
+- Updates all tokens naming and simplifies the global styles. (#407)
+- Changes `theme.scss` file to `global/tokens.scss`. (#407)
+
+### Deprecated
+
+- useWindowDimensions hook (#328)
+
+### Removed
+
+- Frontend computation in favor of backend processing (#411)
+- Removing hooks folder and migrating these hooks to sdk ou inline them on components (#377)
+- gatsby-plugin-offline due to CLS on recurrent users (#348)
+- useWindowDimensions hook (#340)
+- Removes unused `<FacetedFilter/>` component (#345)
+- Unnecessary map at hooks (#323)
+- API style redirects from `/_v/private/graphql` since they have no effect (#310)
+- Display box from `<ProductCard/>` component (#354)
+- `useTotalCount` hook (#362)
+- Phosphor-react library (#378)
+- `main::store::postalCode` value from storage. (#388)
+
+### Fixed
+
+- Unnecessary app rerender after login feature (#418)
+- Fix typos found across the codebase (#412)
+- Fix border style for Product Card and its skeleton on mobile (#379)
+- The divisor for the `Breadcrumb` component not rendering valid HTML. (#365)
+- useBuyButton/useRemoveButton hooks with inconsistent typings/behaviors (#360)
+- React tree re-rendering (#328)
+- Footer rendering pipeline (#328)
+- Scroll lock when transitioning pages on mobile via `SlideOver` component navigation (#344)
+- Filter Button specificity on desktop (#346)
+- Filter facets are not being selected on mobile (#380)
+- `CartItem` image size and truncate long product's title (#405)
+- Entrusting the definition of the cursor property to the browser (#419)
 
 ## [0.1.1] - 2022-02-07
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR updates the CHANGELOG so it matches it's [March Release Notes](https://faststore.dev/releases/2022/04/01/basestore). 
I've also added the identifier of the PR to each CHANGELOG entry so we don't need to rely on git blame to identify the PR responsible for the entry.

## How does it work?

Each entry that was merged before #392 was added to the 0.2.0 section. A new [Github release](https://github.com/vtex-sites/base.store/releases/tag/v0.2.0) was also added to reflect this state.

Each entry after this is still in the Unreleased section.

## How to test it?

Check if the CHANGELOG makes sense and doesn't have any wrong information.

## References
https://keepachangelog.com/en/1.0.0/

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
