### PR TITLE
Fix: Adds global css import for Modal Provider

### DIFF
--- a/src/sdk/ui/modal/Provider.tsx
+++ b/src/sdk/ui/modal/Provider.tsx
@@ -7,8 +7,6 @@ import React, {
 } from 'react'
 import type { PropsWithChildren } from 'react'
 
-import './modal-provider.scss'
-
 type FadeType = 'in' | 'out' | undefined
 
 interface BaseContextValue {

--- a/src/styles/global/components.scss
+++ b/src/styles/global/components.scss
@@ -60,3 +60,4 @@
 @import "src/components/ui/SlideOver/slide-over.scss";
 @import "src/components/ui/SROnly/sr-only.scss";
 @import "src/components/ui/Tiles/tiles.scss";
+@import "src/sdk/ui/modal/modal-provider.scss";


### PR DESCRIPTION
Adds missing CSS import from https://github.com/vtex-sites/base.store/pull/426
