### PR TITLE
fix: Tweak logo on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix PLP scroll bug after applying filters for the mobile version (#454)
+- Fixed BaseStore logo right margin on mobile devices (#455)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix PLP scroll bug after applying filters for the mobile version (#454)
 - Fixed BaseStore logo right margin on mobile devices (#455)
+- Fix PLP scroll bug after applying filters for the mobile version (#454)
 
 ### Security
 

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -136,6 +136,10 @@
     width: 100%;
     height: 100%;
   }
+
+  @include media("<tablet") {
+    margin-right: var(--fs-spacing-5);
+  }
 }
 
 .navbar__modal-body {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is going to tweak the BaseStore logo on small mobile devices (e.g. Moto G4)

|Before|After|
|-|-|
|<img width="556" alt="image" src="https://user-images.githubusercontent.com/10616243/161819101-2cbf3522-8a18-45f4-a954-d9c0726ea144.png">|<img width="553" alt="image" src="https://user-images.githubusercontent.com/10616243/161819197-c42e6f7a-c170-4a3b-864b-86ca97cc96ad.png">|

## How does it work?

Just used a media query to set a right margin on devices smaller than a tablet. 
```
@include media("<tablet") {
    margin-right: var(--fs-spacing-5);
  }
```

## How to test it?

Just run the preview in mobile version and choose a small layout.

## References

Related to #447
Problem caught by @tlgimenes. Tks ✨ 
[How to make a good Changelog](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first) via @filipewl 

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
