### PR TITLE
Fixes search input margin left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `SearchInput` margin left on mobile (#457)
 - Fix PLP scroll bug after applying filters for the mobile version (#454)
 
 ### Security

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -98,6 +98,7 @@
     [data-store-search-input] {
       flex: 1 1;
       margin-right: 0.625rem;
+      margin-left: var(--fs-spacing-9);
 
       [data-store-input] {
         width: calc(100% - var(--fs-spacing-7));


### PR DESCRIPTION
## What's the purpose of this pull request?

Fixes the search input margin-left mentioned previously [here](https://github.com/vtex-sites/base.store/pull/455#pullrequestreview-932314333).

|Before|After|
|-|-|
|![M41MNHL4OQ](https://user-images.githubusercontent.com/11325562/161831131-a306b615-009e-4a33-b9a8-c907fb173db4.gif)|![Qmm3uRHlMc](https://user-images.githubusercontent.com/11325562/161831253-a4cef7a8-82c4-4cdb-b720-490e6c6998f4.gif)|

## How to test it?

Compare the preview version with the older versions.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
