### PR TITLE
Fix: Tweaks layout section spacings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix layout section spacings style (#469)
 
 ### Security
 

--- a/src/styles/global/layout.scss
+++ b/src/styles/global/layout.scss
@@ -19,12 +19,12 @@ main,
 }
 
 .layout__section {
-  padding-top: var(--fs-spacing-4);
   padding-bottom: var(--fs-spacing-4);
+  margin-top: var(--fs-spacing-4);
 
   @include media(">=notebook") {
-    padding-top: var(--fs-grid-padding);
     padding-bottom: var(--fs-grid-padding);
+    margin-top: var(--fs-grid-padding);
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR fixes the spaces (padding/margin) on elements that use the `layout__section` class.

## How does it work?

We changed the spacings from margin to padding on #464 due to a problem with the `box-shadow` on the `product-card`. At first glance, it was good, but it causes a regression with PDP due to margin collapse. So we just change the style from `padding-top` to `margin-top` again and it works as expected.

|Before|After|
|-|-|
|<img width="1399" alt="Screen Shot 2022-04-08 at 12 21 11" src="https://user-images.githubusercontent.com/11325562/162472892-b059a371-a8f1-4578-a94b-4d509295214b.png">|<img width="1400" alt="Screen Shot 2022-04-08 at 12 19 03" src="https://user-images.githubusercontent.com/11325562/162472362-2bfc5048-a69f-40d8-8885-5dda308179b7.png">|

## How to test it?

The elements with the layout__section class should look like the previews before the #464.

## References
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing

## Checklist

- [x] CHANGELOG entry added
