### PR TITLE
Fix: unused css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix unused CSS problem by separating imports into different files for each page (#473)
 - Potential layout shift on Hero section fixed (#472)
 - Fix layout section spacings style (#469)
 

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -3,7 +3,6 @@ import './src/styles/global/tokens.scss'
 import './src/styles/global/resets.scss'
 import './src/styles/global/typography.scss'
 import './src/styles/global/layout.scss'
-import './src/styles/global/components.scss'
 
 import { CartProvider, SessionProvider, UIProvider } from '@faststore/sdk'
 import Layout from 'src/Layout'

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -6,6 +6,8 @@ import Toast from 'src/components/common/Toast'
 import { useUI } from 'src/sdk/ui'
 import type { PropsWithChildren } from 'react'
 
+import 'src/styles/pages/layout.scss'
+
 const CartSidebar = lazy(() => import('src/components/cart/CartSidebar'))
 
 function Layout({ children }: PropsWithChildren<unknown>) {

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -20,6 +20,8 @@ import type {
 import type { PageProps } from 'gatsby'
 import type { SearchState } from '@faststore/sdk'
 
+import 'src/styles/pages/plp.scss'
+
 type Props = PageProps<
   CollectionPageQueryQuery,
   CollectionPageQueryQueryVariables,

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -17,6 +17,8 @@ import type {
 } from '@generated/graphql'
 import { ITEMS_PER_SECTION } from 'src/constants'
 
+import 'src/styles/pages/pdp.scss'
+
 export type Props = PageProps<
   ProductPageQueryQuery,
   ProductPageQueryQueryVariables,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,8 @@ import { ITEMS_PER_SECTION } from 'src/constants'
 import type { PageProps } from 'gatsby'
 import type { HomePageQueryQuery } from '@generated/graphql'
 
+import 'src/styles/pages/homepage.scss'
+
 export type Props = PageProps<HomePageQueryQuery>
 
 function Page(props: Props) {

--- a/src/pages/s.tsx
+++ b/src/pages/s.tsx
@@ -15,6 +15,8 @@ import type {
   SearchPageQueryQueryVariables,
 } from '@generated/graphql'
 
+import 'src/styles/pages/search.scss'
+
 export type Props = PageProps<
   SearchPageQueryQuery,
   SearchPageQueryQueryVariables

--- a/src/styles/pages/homepage.scss
+++ b/src/styles/pages/homepage.scss
@@ -1,0 +1,10 @@
+// Sections
+@import "src/components/sections/BannerText/banner-text.scss";
+@import "src/components/sections/ProductShelf/product-shelf.scss";
+@import "src/components/sections/Section/section.scss";
+
+// UI
+@import "src/components/ui/Button/button.scss";
+@import "src/components/ui/Hero/hero.scss";
+@import "src/components/ui/Link/link.scss";
+@import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/homepage.scss
+++ b/src/styles/pages/homepage.scss
@@ -1,10 +1,21 @@
+// Product
+@import "src/components/product/ProductCard/product-card.scss";
+
 // Sections
 @import "src/components/sections/BannerText/banner-text.scss";
 @import "src/components/sections/ProductShelf/product-shelf.scss";
 @import "src/components/sections/Section/section.scss";
 
+// Skeletons
+@import "src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss";
+@import "src/components/skeletons/ProductTilesSkeleton/ProductTileSkeleton/product-tile-skeleton.scss";
+@import "src/components/skeletons/Shimmer/shimmer.scss";
+@import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
+
 // UI
-@import "src/components/ui/Button/button.scss";
+@import "src/components/ui/Badge/badge.scss";
+@import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
-@import "src/components/ui/Link/link.scss";
+@import "src/components/ui/Image/image.scss";
+@import "src/components/ui/Price/price.scss";
 @import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -1,5 +1,8 @@
 // Cart
+@import "src/components/cart/CartItem/cart-item.scss";
 @import "src/components/cart/CartToggle/cart-toggle.scss";
+@import "src/components/cart/CartSidebar/cart-sidebar.scss";
+@import "src/components/cart/OrderSummary/order-summary.scss";
 
 // Common
 @import "src/components/common/Footer/footer.scss";

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -1,0 +1,19 @@
+// Cart
+@import "src/components/cart/CartToggle/cart-toggle.scss";
+
+// Common
+@import "src/components/common/Footer/footer.scss";
+@import "src/components/common/Navbar/navbar.scss";
+@import "src/components/common/PostalCode/postal-code-input.scss";
+@import "src/components/common/SearchInput/search-input.scss";
+
+// Sections
+@import "src/components/sections/Incentives/incentives.scss";
+
+// UI
+@import "src/components/ui/Accordion/accordion.scss";
+@import "src/components/ui/Alert/alert.scss";
+@import "src/components/ui/Button/button.scss";
+@import "src/components/ui/Link/link.scss";
+@import "src/components/ui/SlideOver/slide-over.scss";
+@import "src/components/ui/SROnly/sr-only.scss";

--- a/src/styles/pages/pdp.scss
+++ b/src/styles/pages/pdp.scss
@@ -1,0 +1,19 @@
+// Product
+@import "src/components/product/OutOfStock/out-of-stock.scss";
+
+// Sections
+@import "src/components/sections/ProductDetails/product-details.scss";
+@import "src/components/sections/ProductShelf/product-shelf.scss";
+@import "src/components/sections/Section/section.scss";
+
+// Skeletons
+@import "src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss";
+@import "src/components/skeletons/Shimmer/shimmer.scss";
+@import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
+
+// UI
+@import "src/components/ui/Breadcrumb/breadcrumb.scss";
+@import "src/components/ui/Image/image.scss";
+@import "src/components/ui/Price/price.scss";
+@import "src/components/ui/ProductTitle/product-title.scss";
+@import "src/components/ui/QuantitySelector/quantity-selector.scss";

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -20,6 +20,7 @@
 // UI
 @import "src/components/ui/Badge/badge.scss";
 @import "src/components/ui/Breadcrumb/breadcrumb.scss";
+@import "src/components/ui/Checkbox/checkbox.scss";
 @import "src/components/ui/EmptyState/empty-state.scss";
 @import "src/components/ui/Hero/hero.scss";
 @import "src/components/ui/Image/image.scss";

--- a/src/styles/pages/plp.scss
+++ b/src/styles/pages/plp.scss
@@ -1,0 +1,29 @@
+// Product
+@import "src/components/product/ProductCard/product-card.scss";
+@import "src/components/product/ProductGrid/product-grid.scss";
+
+// Search
+@import "src/components/search/Filter/filter.scss";
+
+// Sections
+@import "src/components/sections/Breadcrumb/breadcrumb.scss";
+@import "src/components/sections/ProductGallery/product-gallery.scss";
+@import "src/components/sections/ScrollToTopButton/scroll-to-top-button.scss";
+@import "src/components/sections/Section/section.scss";
+
+// Skeletons
+@import "src/components/skeletons/FilterSkeleton/filter-skeleton.scss";
+@import "src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss";
+@import "src/components/skeletons/Shimmer/shimmer.scss";
+@import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
+
+// UI
+@import "src/components/ui/Badge/badge.scss";
+@import "src/components/ui/Breadcrumb/breadcrumb.scss";
+@import "src/components/ui/EmptyState/empty-state.scss";
+@import "src/components/ui/Hero/hero.scss";
+@import "src/components/ui/Image/image.scss";
+@import "src/components/ui/Price/price.scss";
+@import "src/components/ui/ProductTitle/product-title.scss";
+@import "src/components/ui/Select/select.scss";
+@import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/pages/search.scss
+++ b/src/styles/pages/search.scss
@@ -1,0 +1,3 @@
+// Sections
+@import "src/components/sections/Breadcrumb/breadcrumb.scss";
+@import "src/components/sections/ProductGallery/product-gallery.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to split the CSS per page and analyze the unused CSS metric.

Continue on https://github.com/vtex-sites/base.store/pull/480

## How does it work?

With these changes, we aim to reduce the unused imported CSS by following the approach that separates CSS imports into different files for each page.

## References

- [Remove unused CSS rule](https://web.dev/unused-css-rules/)

## Checklist

- [x] CHANGELOG entry added