### PR TITLE
Adjust Incentives to render CMS data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update Incentives to handle CMS data (#474)
 - Applies new local tokens to `ProductShelf` component (#464)
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update Incentives to handle CMS data (#474)
+- Update the Incentives component to handle CMS data (#474)
 - Applies new local tokens to `ProductShelf` component (#464)
 
 ### Deprecated

--- a/src/components/sections/Incentives/Incentives.tsx
+++ b/src/components/sections/Incentives/Incentives.tsx
@@ -1,8 +1,8 @@
 import { Incentive as UIIncentive, List as UIList } from '@faststore/ui'
-import type { ReactNode } from 'react'
+import Icon from 'src/components/ui/Icon'
 
 interface Incentive {
-  icon: ReactNode
+  icon: string
   title?: string
   firstLineText: string
   secondLineText?: string
@@ -20,7 +20,7 @@ function Incentives({ incentives, classes = '' }: Props) {
         {incentives.map((incentive, index) => (
           <li key={String(index)}>
             <UIIncentive>
-              {incentive.icon}
+              <Icon name={incentive.icon} width={32} height={32} />
               <div data-incentive-content>
                 {incentive.title && <p>{incentive.title}</p>}
                 <span>{incentive.firstLineText}</span>

--- a/src/components/sections/Incentives/IncentivesFooter.tsx
+++ b/src/components/sections/Incentives/IncentivesFooter.tsx
@@ -1,37 +1,8 @@
-import Icon from 'src/components/ui/Icon'
-
 import Incentives from './Incentives'
+import IncentivesMock from './incentivesMock'
 
 function IncentivesFooter() {
-  const incentives = [
-    {
-      icon: <Icon name="ShieldCheck" width={32} height={32} />,
-      firstLineText: 'Trusted',
-      secondLineText: 'by SafeCon',
-    },
-    {
-      icon: <Icon name="Medal" width={32} height={32} />,
-      firstLineText: 'Quality',
-      secondLineText: 'Products',
-    },
-    {
-      icon: <Icon name="CircleWavyCheck" width={32} height={32} />,
-      firstLineText: '3-years',
-      secondLineText: 'Guarantee',
-    },
-    {
-      icon: <Icon name="Storefront" width={32} height={32} />,
-      firstLineText: 'Pickup',
-      secondLineText: 'Options',
-    },
-    {
-      icon: <Icon name="Truck" width={32} height={32} />,
-      firstLineText: 'Free',
-      secondLineText: 'Shipping',
-    },
-  ]
-
-  return <Incentives incentives={incentives} />
+  return <Incentives incentives={IncentivesMock} />
 }
 
 export default IncentivesFooter

--- a/src/components/sections/Incentives/IncentivesHeader.tsx
+++ b/src/components/sections/Incentives/IncentivesHeader.tsx
@@ -10,7 +10,6 @@ interface Incentive {
 
 interface Props {
   incentives: Incentive[]
-  classes?: string
 }
 
 function IncentivesHeader({ incentives }: Props) {

--- a/src/components/sections/Incentives/IncentivesHeader.tsx
+++ b/src/components/sections/Incentives/IncentivesHeader.tsx
@@ -1,37 +1,19 @@
-import Icon from 'src/components/ui/Icon'
-
 import Incentives from './Incentives'
 import Section from '../Section'
 
-const incentives = [
-  {
-    icon: <Icon name="Truck" width={32} height={32} />,
-    title: 'Buy online',
-    firstLineText: 'Get Free Shipping',
-  },
-  {
-    icon: <Icon name="Calendar" width={32} height={32} />,
-    title: 'Free return',
-    firstLineText: '30 days to return',
-  },
-  {
-    icon: <Icon name="Gift" width={32} height={32} />,
-    title: 'Gift cards',
-    firstLineText: '$20 / $30 / $50',
-  },
-  {
-    icon: <Icon name="Storefront" width={32} height={32} />,
-    title: 'Physical Stores',
-    firstLineText: '+40 Stores in Brazil',
-  },
-  {
-    icon: <Icon name="ShieldCheck" width={32} height={32} />,
-    title: 'Buy online',
-    firstLineText: 'Get Free Shipping',
-  },
-]
+interface Incentive {
+  icon: string
+  title?: string
+  firstLineText: string
+  secondLineText?: string
+}
 
-function IncentivesHeader() {
+interface Props {
+  incentives: Incentive[]
+  classes?: string
+}
+
+function IncentivesHeader({ incentives }: Props) {
   return (
     <Section>
       <Incentives incentives={incentives} classes="incentives--colored" />

--- a/src/components/sections/Incentives/incentivesMock.js
+++ b/src/components/sections/Incentives/incentivesMock.js
@@ -1,0 +1,29 @@
+const incentives = [
+  {
+    icon: 'ShieldCheck',
+    firstLineText: 'Trusted',
+    secondLineText: 'by SafeCon',
+  },
+  {
+    icon: 'Medal',
+    firstLineText: 'Quality',
+    secondLineText: 'Products',
+  },
+  {
+    icon: 'CircleWavyCheck',
+    firstLineText: '3-years',
+    secondLineText: 'Guarantee',
+  },
+  {
+    icon: 'Storefront',
+    firstLineText: 'Pickup',
+    secondLineText: 'Options',
+  },
+  {
+    icon: 'Truck',
+    firstLineText: 'Free',
+    secondLineText: 'Shipping',
+  },
+]
+
+export default incentives

--- a/src/components/sections/Incentives/incentivesMock.js
+++ b/src/components/sections/Incentives/incentivesMock.js
@@ -1,29 +1,29 @@
-const incentives = [
+const incentivesMock = [
   {
-    icon: 'ShieldCheck',
-    firstLineText: 'Trusted',
-    secondLineText: 'by SafeCon',
+    icon: 'Truck',
+    title: 'Buy online',
+    firstLineText: 'Get Free Shipping',
   },
   {
-    icon: 'Medal',
-    firstLineText: 'Quality',
-    secondLineText: 'Products',
+    icon: 'Calendar',
+    title: 'Free return',
+    firstLineText: '30 days to return',
   },
   {
-    icon: 'CircleWavyCheck',
-    firstLineText: '3-years',
-    secondLineText: 'Guarantee',
+    icon: 'Gift',
+    title: 'Gift cards',
+    firstLineText: '$20 / $30 / $50',
   },
   {
     icon: 'Storefront',
-    firstLineText: 'Pickup',
-    secondLineText: 'Options',
+    title: 'Physical Stores',
+    firstLineText: '+40 Stores in Brazil',
   },
   {
-    icon: 'Truck',
-    firstLineText: 'Free',
-    secondLineText: 'Shipping',
+    icon: 'ShieldCheck',
+    title: 'Buy online',
+    firstLineText: 'Get Free Shipping',
   },
 ]
 
-export default incentives
+export default incentivesMock

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,6 +10,7 @@ import { mark } from 'src/sdk/tests/mark'
 import { ITEMS_PER_SECTION } from 'src/constants'
 import type { PageProps } from 'gatsby'
 import type { HomePageQueryQuery } from '@generated/graphql'
+import IncentivesMock from 'src/components/sections/Incentives/incentivesMock'
 
 export type Props = PageProps<HomePageQueryQuery>
 
@@ -73,7 +74,7 @@ function Page(props: Props) {
         imageAlt="Quest 2 Controller on a table"
       />
 
-      <IncentivesHeader />
+      <IncentivesHeader incentives={IncentivesMock} />
 
       <ProductShelf
         first={ITEMS_PER_SECTION}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to keep the `Incentives` component synced after changes made in the forked project [storeframework](https://github.com/vtex-sites/storeframework.store/pull/47).

## How does it work?

This PR used cherry-pick to copy code updates from [storeframework](https://github.com/vtex-sites/storeframework.store/pull/47), and mocked the Incentives in `incentivesMock.js `file.

## How to test it?

Nothing special to be tested, just run the project and see the `IncentivesHeader` and `IncentivesFooter` working properly.

## References

- Storeframework [PR](https://github.com/vtex-sites/storeframework.store/pull/47) with final integration with CMS
- Related [Jira Task](https://vtex-dev.atlassian.net/browse/FSSS-261)
- Git cherry-pick [documentation](https://git-scm.com/docs/git-cherry-pick)

## Checklist

- [x] CHANGELOG entry added
