### PR TITLE
Add missing styles to layout.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removes CSS imports of components that are not being used (#476)
 
 ### Fixed
+- Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)
 - Fix unused CSS problem by separating imports into different files for each page (#473)
 - Potential layout shift on Hero section fixed (#472)
 - Fix layout section spacings style (#469)
-- Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix unused CSS problem by separating imports into different files for each page (#473)
 - Potential layout shift on Hero section fixed (#472)
 - Fix layout section spacings style (#469)
+- Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss (#488)
 
 ### Security
 

--- a/src/styles/pages/layout.scss
+++ b/src/styles/pages/layout.scss
@@ -9,6 +9,12 @@
 @import "src/components/common/Navbar/navbar.scss";
 @import "src/components/common/SearchInput/search-input.scss";
 
+// Regionalization
+@import "src/components/regionalization/RegionalizationBar/regionalization-bar.scss";
+@import "src/components/regionalization/RegionalizationButton/regionalization-button.scss";
+@import "src/components/regionalization/RegionalizationInput/regionalization-input.scss";
+@import "src/components/regionalization/RegionalizationModal/regionalization-modal.scss";
+
 // Sections
 @import "src/components/sections/Incentives/incentives.scss";
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix styling issue on Regionalization Modal by adding the missing imports in layout.scss

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
