### PR TITLE
Feat: Creates Picture Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds `Picture` component and `useSources` hook (#489)
 - Applies new local tokens to `Badge` (#462)
 - Applies new local tokens to `Hero` (#435)
 - Applies new local tokens to `Quantity Selector` (#448)

--- a/src/components/ui/Image/Picture.tsx
+++ b/src/components/ui/Image/Picture.tsx
@@ -46,5 +46,4 @@ function Picture({
   )
 }
 
-Picture.displayName = 'Picture'
 export default memo(Picture)

--- a/src/components/ui/Image/Picture.tsx
+++ b/src/components/ui/Image/Picture.tsx
@@ -1,6 +1,6 @@
-import type { HTMLAttributes } from 'react'
-import { memo } from 'react'
+import React, { memo } from 'react'
 import { Helmet } from 'react-helmet'
+import type { HTMLAttributes } from 'react'
 
 import { useSources } from './useSources'
 import type { SourceOptions } from './useSources'
@@ -23,7 +23,7 @@ function Picture({
     <picture>
       {sources.map(({ srcSet, media, preloadLinks }, index) => {
         return (
-          <>
+          <React.Fragment key={index}>
             {preload && (
               <Helmet
                 link={preloadLinks.map(
@@ -38,7 +38,7 @@ function Picture({
               />
             )}
             <source key={index} srcSet={srcSet} media={media} />
-          </>
+          </React.Fragment>
         )
       })}
       <img {...imgProps} alt={imgProps.alt} />

--- a/src/components/ui/Image/Picture.tsx
+++ b/src/components/ui/Image/Picture.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from 'react'
+import { memo } from 'react'
+
+import { useSources } from './useSources'
+import type { SourceOptions } from './useSources'
+import type { ImageOptions } from './useImage'
+
+interface Props extends HTMLAttributes<HTMLPictureElement> {
+  sources: SourceOptions[]
+  img: ImageOptions
+}
+
+function Picture({ sources: sourceOptions, img: imgProps }: Props) {
+  const sources = useSources(sourceOptions)
+
+  return (
+    <picture>
+      {sources.map(({ srcSet, media }, index) => {
+        return <source key={index} srcSet={srcSet} media={media} />
+      })}
+      <img {...imgProps} alt={imgProps.alt} />
+    </picture>
+  )
+}
+
+Picture.displayName = 'Picture'
+export default memo(Picture)

--- a/src/components/ui/Image/Picture.tsx
+++ b/src/components/ui/Image/Picture.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from 'react'
 import { memo } from 'react'
+import { Helmet } from 'react-helmet'
 
 import { useSources } from './useSources'
 import type { SourceOptions } from './useSources'
@@ -8,15 +9,37 @@ import type { ImageOptions } from './useImage'
 interface Props extends HTMLAttributes<HTMLPictureElement> {
   sources: SourceOptions[]
   img: ImageOptions
+  preload?: boolean
 }
 
-function Picture({ sources: sourceOptions, img: imgProps }: Props) {
+function Picture({
+  sources: sourceOptions,
+  img: imgProps,
+  preload = false,
+}: Props) {
   const sources = useSources(sourceOptions)
 
   return (
     <picture>
-      {sources.map(({ srcSet, media }, index) => {
-        return <source key={index} srcSet={srcSet} media={media} />
+      {sources.map(({ srcSet, media, preloadLinks }, index) => {
+        return (
+          <>
+            {preload && (
+              <Helmet
+                link={preloadLinks.map(
+                  (href: string) =>
+                    ({
+                      as: 'image',
+                      rel: 'preload',
+                      href,
+                      media,
+                    } as any)
+                )}
+              />
+            )}
+            <source key={index} srcSet={srcSet} media={media} />
+          </>
+        )
       })}
       <img {...imgProps} alt={imgProps.alt} />
     </picture>

--- a/src/components/ui/Image/index.tsx
+++ b/src/components/ui/Image/index.tsx
@@ -1,1 +1,2 @@
 export { default as Image } from './Image'
+export { default as Picture } from './Picture'

--- a/src/components/ui/Image/useSources.ts
+++ b/src/components/ui/Image/useSources.ts
@@ -15,11 +15,16 @@ export interface SourceOptions extends SourceProps {
   options?: ThumborOptions
 }
 
+export interface SourceHTMLAttributesPreload
+  extends SourceHTMLAttributes<HTMLSourceElement> {
+  preloadLinks: string[]
+}
+
 const FACTORS = [1, 2, 3]
 
 export const useSources = (
   sourcesOptions: SourceOptions[]
-): Array<SourceHTMLAttributes<HTMLSourceElement>> => {
+): SourceHTMLAttributesPreload[] => {
   return useMemo(() => {
     return sourcesOptions.map((sourceOption) => {
       const { src: baseUrl, width, height, media, options = {} } = sourceOption
@@ -32,7 +37,9 @@ export const useSources = (
         return `${builder(rescaledWidth, height * factor)} ${rescaledWidth}w`
       })
 
-      return { media, srcSet: srcs.join(', ') }
+      const preloadLinks = srcs.map((src) => src.split(' ')[0])
+
+      return { media, srcSet: srcs.join(', '), preloadLinks }
     })
   }, [sourcesOptions])
 }

--- a/src/components/ui/Image/useSources.ts
+++ b/src/components/ui/Image/useSources.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import type { SourceHTMLAttributes } from 'react'
+
+import { urlBuilder } from './thumborUrlBuilder'
+import type { ThumborOptions } from './thumborUrlBuilder'
+
+export interface SourceProps extends SourceHTMLAttributes<HTMLSourceElement> {
+  src: string
+  width: number
+  height: number
+  media: string
+}
+
+export interface SourceOptions extends SourceProps {
+  options?: ThumborOptions
+}
+
+const FACTORS = [1, 2, 3]
+
+export const useSources = (
+  sourcesOptions: SourceOptions[]
+): Array<SourceHTMLAttributes<HTMLSourceElement>> => {
+  const sources = useMemo(() => {
+    return sourcesOptions.map((sourceOption) => {
+      const { src: baseUrl, width, height, media, options = {} } = sourceOption
+
+      const builder = urlBuilder(baseUrl, options)
+
+      const srcs = FACTORS.map((factor) => {
+        const rescaledWidth = width * factor
+
+        return `${builder(rescaledWidth, height * factor)} ${rescaledWidth}w`
+      })
+
+      return { media, srcSet: srcs.join(', ') }
+    })
+  }, [sourcesOptions])
+
+  return sources
+}

--- a/src/components/ui/Image/useSources.ts
+++ b/src/components/ui/Image/useSources.ts
@@ -20,7 +20,7 @@ const FACTORS = [1, 2, 3]
 export const useSources = (
   sourcesOptions: SourceOptions[]
 ): Array<SourceHTMLAttributes<HTMLSourceElement>> => {
-  const sources = useMemo(() => {
+  return useMemo(() => {
     return sourcesOptions.map((sourceOption) => {
       const { src: baseUrl, width, height, media, options = {} } = sourceOption
 
@@ -35,6 +35,4 @@ export const useSources = (
       return { media, srcSet: srcs.join(', ') }
     })
   }, [sourcesOptions])
-
-  return sources
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Creates the `Picture` component and `useSources` hook.

## How does it work?

While analyzing some of our client's projects, I noticed a problem regarding the way the images were loading when we have multiples breakpoints, like mobile and desktop.

Taking into consideration that we may want to load different images according to the device (Art Direction) and we were controlling what will be shown using CSS (`display-mobile` and `hidden-mobile` classes), the browser was downloading at least two images, one time for mobile and another for desktop.

Example:
```js
<Banner>
  <Image
    className="display-mobile"
    alt={altMobile}
    src={srcMobile}
    width={widthMobile}
    height={heightMobile}
  />
  <Image
    className="hidden-mobile"
    alt={altDesktop}
    src={srcDesktop}
    width={widthDesktop}
    height={heightDesktop}
  />
</Banner>
```

Since the HTML5 provides the `<picture>` tag along with `<source>`, `srcset`, and `media` queries, we can pass some of them and the browser will download just the best option for the device screen width and pixel density. So, we can pass these options instead of controlling everything using CSS, what decreases the DOM size, CSS classes, and also we can save the bandwidth downloading smaller images. Thus, speeds up page load times.

`<picture>` will download all image sources as needed and dynamically show the appropriate at the time, even if the user changes the dimensions of the page.  Its main use is Art Direction (when you want to show a differently shaped picture under different conditions. Maybe you want to show a cropped version of the picture on mobile or scale some text (e.g. small text that would become unreadable when scaled).

Why not use the `Image` component?

The `Image` component is recommended when we just have one image (mobile or desktop) and we would like to have **multiples copies of the same image**, preserving the aspect ratio for all image copies with more or fewer pixels. When we would like to have **different images for different screens**, the `<picture>` tag is recommended.

Multiples copies of the same image:
<img width="844" alt="Screen Shot 2022-04-20 at 16 59 33" src="https://user-images.githubusercontent.com/11325562/164313193-075ccc42-ac27-4e6a-9e45-8dbe5448b7f3.png">

Different images for different screens:
<img width="698" alt="Screen Shot 2022-04-20 at 16 59 18" src="https://user-images.githubusercontent.com/11325562/164313237-5e0d8745-f2f4-4d02-8770-061cb364c46f.png">
<img width="777" alt="Screen Shot 2022-04-20 at 17 03 36" src="https://user-images.githubusercontent.com/11325562/164313482-d788ee45-d04d-47d6-9b36-66807d01eba8.png">

## How to test it?

So far on base.store we don't have the Art Direction problem (maybe on Hero or Tiles afterward?). If we decided to change the implementation of these components we can test better.

Example of use:
```js
<Picture
  sources={[
    {
      src: srcMobile,
      width: widthMobile,
      height: heightMobile,
      media: '(max-width: 767px)',
    },
    {
      src: srcDesktop,
      width: widthDesktop,
      height: heightdesktop,
      media: '(min-width: 768px)',
    },
  ]}
  img={{
    src: srcFallback,
    width: widthFallback,
    height: heightFallback,
    alt: altFallback,
    loading: "lazy",
  }}
/>
```

Final markup example:
```js
<picture>
  <source srcset="https://assets.vtex.app/328x435/image328.png 328w, https://assets.vtex.app/656x870/image656.png 656w, https://assets.vtex.app/984x1305/image984.png 984w" media="(max-width: 767px)">
  <source srcset="https://assets.vtex.app/1304x636/image1304.png 1304w, https://assets.vtex.app/2608x1272/image2608.png 2608w, https://assets.vtex.app/3912x1908/image3912.png 3912w" media="(min-width: 768px)">
  <img src="https://store.vtexassets.com/assets/image.png" width="1304" height="636" alt="Alternative text" loading="lazy">
</picture>
```

## References

https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_image
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
https://blog.bitsrc.io/why-you-should-use-picture-tag-instead-of-img-tag-b9841e86bf8b
https://www.w3schools.com/html/html_images_picture.asp
https://web.dev/preload-responsive-images/#preload-and-lesspicturegreater
https://github.com/vtex-sites/base.store/pull/401

## Checklist

- [x] CHANGELOG entry added
