### PR TITLE
fixed: fix error messages that were avoiding build-storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import '!style-loader!css-loader!sass-loader!../src/styles/global/tokens.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/resets.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/typography.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/layout.scss'
-import '!style-loader!css-loader!sass-loader!../src/styles/global/components.scss'
+import '!style-loader!css-loader!sass-loader!../src/styles/global/utilities.scss'
 
 import SBTheme from './theme'
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@faststore/api": "^1.7.26",
     "@faststore/sdk": "^1.7.26",
     "@faststore/ui": "^1.7.26",
+    "@reach/router": "^1.3.4",
     "@vtex/graphql-utils": "^1.7.26",
     "gatsby": "^4.11.1",
     "gatsby-plugin-gatsby-cloud": "^4.11.1",


### PR DESCRIPTION
## What's the purpose of this pull request?

I want to deploy the Base Store Storybook with Vercel or Netlify, but I was facing the following errors with build-storybook:

<img width="1361" alt="Screen Shot 2022-04-20 at 21 09 29" src="https://user-images.githubusercontent.com/60782333/164344351-ee8446e7-3afd-4d85-b1d6-155a56dc18b4.png">
<img width="1361" alt="Screen Shot 2022-04-20 at 21 09 54" src="https://user-images.githubusercontent.com/60782333/164344385-251f8ddf-4437-44de-9dad-8f791c6fc79e.png">

## How does it work?

Fixes the errors above

## How to test it?

Run `yarn build-storybook`

## Checklist

<em>You may erase this after checking them all ;)</em>

- [] CHANGELOG entry added
