### PR TITLE
fix: Brings back components.scss for storybook and add @reach/router to package.json

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import '!style-loader!css-loader!sass-loader!../src/styles/global/tokens.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/resets.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/typography.scss'
 import '!style-loader!css-loader!sass-loader!../src/styles/global/layout.scss'
-import '!style-loader!css-loader!sass-loader!../src/styles/global/components.scss'
+import '!style-loader!css-loader!sass-loader!../src/styles/global/storybook-components.scss'
 
 import SBTheme from './theme'
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@faststore/api": "^1.7.26",
     "@faststore/sdk": "^1.7.26",
     "@faststore/ui": "^1.7.26",
+    "@reach/router": "^1.3.4",
     "@vtex/graphql-utils": "^1.7.26",
     "gatsby": "^4.11.1",
     "gatsby-plugin-gatsby-cloud": "^4.11.1",

--- a/src/components/product/ProductCard/ProductCard.stories.tsx
+++ b/src/components/product/ProductCard/ProductCard.stories.tsx
@@ -1,5 +1,6 @@
 import { SessionProvider } from '@faststore/sdk'
 import storeConfig from 'store.config'
+import { LocationProvider } from '@reach/router'
 
 import type { ProductCardProps } from '.'
 import ProductCard from '.'
@@ -41,11 +42,13 @@ const product = {
 }
 
 const Template = (args: ProductCardProps) => (
-  <SessionProvider initialState={{ channel: storeConfig.channel }}>
-    <div style={{ width: 300 }}>
-      <ProductCard {...args} />
-    </div>
-  </SessionProvider>
+  <LocationProvider>
+    <SessionProvider initialState={{ channel: storeConfig.channel }}>
+      <div style={{ width: 300 }}>
+        <ProductCard {...args} />
+      </div>
+    </SessionProvider>
+  </LocationProvider>
 )
 
 export const Default = Template.bind({})

--- a/src/styles/global/storybook-components.scss
+++ b/src/styles/global/storybook-components.scss
@@ -1,0 +1,55 @@
+// Cart
+@import "src/components/cart/CartItem/cart-item.scss";
+@import "src/components/cart/CartSidebar/cart-sidebar.scss";
+@import "src/components/cart/CartToggle/cart-toggle.scss";
+@import "src/components/cart/OrderSummary/order-summary.scss";
+
+// Common
+@import "src/components/common/Footer/footer.scss";
+@import "src/components/common/SearchInput/search-input.scss";
+@import "src/components/common/Navbar/navbar.scss";
+
+// Product
+@import "src/components/product/ProductCard/product-card.scss";
+@import "src/components/product/ProductGrid/product-grid.scss";
+@import "src/components/product/OutOfStock/out-of-stock.scss";
+
+// Search
+@import "src/components/search/Filter/filter.scss";
+
+// Sections
+@import "src/components/sections/BannerText/banner-text.scss";
+@import "src/components/sections/Breadcrumb/breadcrumb.scss";
+@import "src/components/sections/Incentives/incentives.scss";
+@import "src/components/sections/ProductDetails/product-details.scss";
+@import "src/components/sections/ProductGallery/product-gallery.scss";
+@import "src/components/sections/ProductShelf/product-shelf.scss";
+@import "src/components/sections/ScrollToTopButton/scroll-to-top-button.scss";
+@import "src/components/sections/Section/section.scss";
+
+// Skeletons
+@import "src/components/skeletons/FilterSkeleton/filter-skeleton.scss";
+@import "src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss";
+@import "src/components/skeletons/ProductTilesSkeleton/ProductTileSkeleton/product-tile-skeleton.scss";
+@import "src/components/skeletons/Shimmer/shimmer.scss";
+@import "src/components/skeletons/SkeletonElement/skeleton-element.scss";
+
+// UI
+@import "src/components/ui/Accordion/accordion.scss";
+@import "src/components/ui/Alert/alert.scss";
+@import "src/components/ui/Badge/badge.scss";
+@import "src/components/ui/Breadcrumb/breadcrumb.scss";
+@import "src/components/ui/Button/button.scss";
+@import "src/components/ui/Checkbox/checkbox.scss";
+@import "src/components/ui/EmptyState/empty-state.scss";
+@import "src/components/ui/Hero/hero.scss";
+@import "src/components/ui/Image/image.scss";
+@import "src/components/ui/InputText/input-text.scss";
+@import "src/components/ui/Link/link.scss";
+@import "src/components/ui/Price/price.scss";
+@import "src/components/ui/ProductTitle/product-title.scss";
+@import "src/components/ui/QuantitySelector/quantity-selector.scss";
+@import "src/components/ui/Select/select.scss";
+@import "src/components/ui/SlideOver/slide-over.scss";
+@import "src/components/ui/SROnly/sr-only.scss";
+@import "src/components/ui/Tiles/tiles.scss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,6 +3460,16 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
+"@reach/router@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
+  integrity sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==
+  dependencies:
+    create-react-context "0.3.0"
+    invariant "^2.2.3"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+
 "@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
@@ -8170,6 +8180,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-context@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -11867,6 +11885,11 @@ graphql@^15.7.2:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@5.1.1:
   version "5.1.1"
@@ -20446,7 +20469,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.12"
 
-warning@^4.0.2:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR adds back `components.scss` as `storybook-components.scss` and adds `@reach/router` to the `package.json`. This avoids errors when running `yarn storybook`

## How to test it?
Verify that you can run `yarn storybook` and all styles are still applied.