### PR TITLE
[WIP] Remove setimmediate import and dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@envelop/graphql-jit": "^1.1.1",
     "@envelop/parser-cache": "^2.2.0",
     "@envelop/validation-cache": "^2.2.0",
-    "@faststore/api": "^1.7.26",
+    "@faststore/api": "https://pkg.csb.dev/vtex/faststore/commit/85ff4cbf/@faststore/api",
     "@faststore/sdk": "^1.7.26",
     "@faststore/ui": "^1.7.26",
     "@reach/router": "^1.3.4",
@@ -51,7 +51,6 @@
     "react-helmet-async": "^1.2.2",
     "react-intersection-observer": "^8.32.5",
     "sass": "^1.44.0",
-    "setimmediate": "^1.0.5",
     "swr": "^1.1.0"
   },
   "devDependencies": {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,4 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-/**
- * Polyfill for dataloader.
- * TODO: Remove it once this is fixed: https://github.com/graphql/dataloader/issues/249
- * */
-import 'setimmediate'
 import {
   envelop,
   useExtendContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,14 +1981,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faststore/api@^1.7.26":
-  version "1.7.26"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-1.7.26.tgz#f3b103569f6237696e7d5569be4fbc0197c538dc"
-  integrity sha512-mij34Sxg8wEvsGfoWgTZyywylsAqQdAUT7hIit+haTutc2ue9DkU95FUA5quPACQ9P3/jCOLOJgQx7s2oI7xeg==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/85ff4cbf/@faststore/api":
+  version "1.7.29"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/85ff4cbf/@faststore/api#af93a18ff6d3495009c936ab4df731db569c79f7"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
-    dataloader "^2.0.0"
+    dataloader "^2.1.0"
     fast-deep-equal "^3.1.3"
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
@@ -8606,10 +8605,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-dataloader@2.0.0, dataloader@^2.0.0:
+dataloader@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
+dataloader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
## What's the purpose of this pull request?

Remove hard dependency on `setimmediate`.

See: https://github.com/vtex/faststore/pull/1236