### PR TITLE
Feat: Update Regionalization Button and Regionalization Bar to show the postal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Applies new local tokens to `BannerText` (#470)
 - Update the Incentives component to handle CMS data (#474)
+- Update `RegionalizationButton` and `RegionalizationBar` to show the postal code (#495)
 
 ### Deprecated
 

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -2,26 +2,26 @@ import type { HTMLAttributes } from 'react'
 import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useSession } from '@faststore/sdk'
 
 interface RegionalizationBarProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationBar({
-  content,
   classes,
   ...otherProps
 }: RegionalizationBarProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-bar className={classes} {...otherProps}>
       <Button onClick={() => setIsRegionalizationModalOpen(true)}>
         <Icon name="MapPin" width={24} height={24} />
-        {content ? (
+        {postalCode ? (
           <>
-            <span>{content}</span>
+            <span>{postalCode}</span>
             <span>Edit</span>
           </>
         ) : (

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -2,18 +2,18 @@ import type { HTMLAttributes } from 'react'
 import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useSession } from '@faststore/sdk'
 
 interface RegionalizationButtonProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationButton({
-  content,
   classes,
   ...otherProps
 }: RegionalizationButtonProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-button className={classes} {...otherProps}>
@@ -24,9 +24,9 @@ export default function RegionalizationButton({
         iconPosition="left"
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
-        {content ? (
+        {postalCode ? (
           <>
-            <span>{content}</span>
+            <span>{postalCode}</span>
           </>
         ) : (
           <span>Set your location</span>


### PR DESCRIPTION
## What's the purpose of this pull request?

Update Regionalization Button and Regionalization Bar to show the last postal code saved, instead of receiving a `content` prop.

![image](https://user-images.githubusercontent.com/22377378/164786815-d827a559-91a7-41f8-897a-c1ef966bc1cd.png)

![image](https://user-images.githubusercontent.com/22377378/164786782-aec331e0-c7d3-44dd-9110-85c161f73288.png)

## How to test it?

Set a valid postal code in `RegionalizationInput` and push the close button.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
